### PR TITLE
Missing member errors only on debug builds

### DIFF
--- a/src/ArgentSquire/WarcraftClient.cs
+++ b/src/ArgentSquire/WarcraftClient.cs
@@ -966,7 +966,11 @@ namespace ArgentSquire
             T item = JsonConvert.DeserializeObject<T>(json, new JsonSerializerSettings
             {
                 ContractResolver = new ArgentSquireContractResolver(),
+#if DEBUG
                 MissingMemberHandling = MissingMemberHandling.Error
+#else
+                MissingMemberHandling = MissingMemberHandling.Ignore
+#endif
             });
 
             return item;


### PR DESCRIPTION
Updated the JSON serialization settings to only throw an exception for a
missing member on debug builds.