### PR TITLE
Use a single instance of HttpClient

### DIFF
--- a/src/ArgentPonyWarcraftClient/Utilities/GlobalHttpClient.cs
+++ b/src/ArgentPonyWarcraftClient/Utilities/GlobalHttpClient.cs
@@ -1,0 +1,19 @@
+﻿using System.Net.Http;
+
+namespace ArgentPonyWarcraftClient.Utilities
+{
+    /// <summary>
+    ///     HttpClient is intended to be instantiated once and re-used throughout the life of an application.
+    ///     Especially in server applications, creating a new HttpClient instance for every request will exhaust the
+    ///     number of sockets available under heavy loads. This will result in SocketException errors.
+    /// </summary>
+    public static class GlobalHttpClient
+    {
+        private static HttpClient _instance;
+
+        /// <summary>
+        ///     Gets the current HttpClient instance.
+        /// </summary>
+        public static HttpClient Instance => _instance ?? (_instance = new HttpClient());
+    }
+}

--- a/src/ArgentPonyWarcraftClient/WarcraftClient.cs
+++ b/src/ArgentPonyWarcraftClient/WarcraftClient.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
+using ArgentPonyWarcraftClient.Utilities;
 using Newtonsoft.Json;
 
 namespace ArgentPonyWarcraftClient
@@ -12,6 +13,8 @@ namespace ArgentPonyWarcraftClient
     /// </summary>
     public class WarcraftClient
     {
+        private readonly HttpClient _client;
+
         /// <summary>
         /// The API key.
         /// </summary>
@@ -47,6 +50,7 @@ namespace ArgentPonyWarcraftClient
         /// <param name="locale">The locale.</param>
         public WarcraftClient(string apiKey, Region region, string locale)
         {
+            _client = GlobalHttpClient.Instance;
             _apiKey = apiKey ?? throw new ArgumentNullException(nameof(apiKey));
             _region = region;
             _locale = locale;
@@ -956,9 +960,8 @@ namespace ArgentPonyWarcraftClient
         private async Task<T> Get<T>(string requestUri)
         {
             // Retrieve the response.  Throw an error if we had a problem.
-            var client = new HttpClient();
-            client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            HttpResponseMessage response = await client.GetAsync(requestUri);
+            _client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            HttpResponseMessage response = await _client.GetAsync(requestUri);
             response.EnsureSuccessStatusCode();
 
             // Deserialize an object of type T from the JSON string.


### PR DESCRIPTION
HttpClient is intended to be instantiated once and re-used throughout the life of an application.
Especially in server applications, creating a new HttpClient instance for every request will exhaust the
number of sockets available under heavy loads. This will result in SocketException errors.

To reslove this issue I created a singleton class and everytime you create a new WarcraftClient it will grab the current HttpClient instasnce.