### PR TITLE
Feature/warcraftclient interface

### DIFF
--- a/src/ArgentPonyWarcraftClient.Tests/WarcraftClientTests.cs
+++ b/src/ArgentPonyWarcraftClient.Tests/WarcraftClientTests.cs
@@ -24,7 +24,7 @@ namespace ArgentPonyWarcraftClient.Tests
         [Fact]
         public async void GetAchievementAsync_Gets_Achievement()
         {
-            var warcraftClient = new WarcraftClient(_apiKey);
+            IWarcraftClient warcraftClient = new WarcraftClient(_apiKey);
             RequestResult<Achievement> result = await warcraftClient.GetAchievementAsync(2144);
             Assert.NotNull(result.Value);
         }
@@ -32,7 +32,7 @@ namespace ArgentPonyWarcraftClient.Tests
         [Fact]
         public async void GetAuctionAsync_Gets_Auction()
         {
-            var warcraftClient = new WarcraftClient(_apiKey);
+            IWarcraftClient warcraftClient = new WarcraftClient(_apiKey);
             RequestResult<AuctionFiles> result = await warcraftClient.GetAuctionAsync("Norgannon");
             Assert.NotNull(result.Value.Files);
 
@@ -43,7 +43,7 @@ namespace ArgentPonyWarcraftClient.Tests
         [Fact]
         public async void GetBattlegroupAsync_Gets_Battlegroups()
         {
-            var warcraftClient = new WarcraftClient(_apiKey);
+            IWarcraftClient warcraftClient = new WarcraftClient(_apiKey);
             RequestResult<IList<Battlegroup>> result = await warcraftClient.GetBattlegroupsAsync();
             Assert.NotNull(result.Value);
             Assert.NotEmpty(result.Value);
@@ -52,7 +52,7 @@ namespace ArgentPonyWarcraftClient.Tests
         [Fact]
         public async void GetBossAsync_Gets_Boss()
         {
-            var warcraftClient = new WarcraftClient(_apiKey);
+            IWarcraftClient warcraftClient = new WarcraftClient(_apiKey);
             RequestResult<Boss> result = await warcraftClient.GetBossAsync(24723);
             Assert.NotNull(result.Value);
         }
@@ -60,7 +60,7 @@ namespace ArgentPonyWarcraftClient.Tests
         [Fact]
         public async void GetBossesAsync_Gets_Bosses()
         {
-            var warcraftClient = new WarcraftClient(_apiKey);
+            IWarcraftClient warcraftClient = new WarcraftClient(_apiKey);
             RequestResult<IList<Boss>> result = await warcraftClient.GetBossesAsync();
             Assert.NotNull(result.Value);
             Assert.NotEmpty(result.Value);
@@ -69,7 +69,7 @@ namespace ArgentPonyWarcraftClient.Tests
         [Fact]
         public async void GetChallengesAsync_Gets_Challenges_For_Region()
         {
-            var warcraftClient = new WarcraftClient(_apiKey);
+            IWarcraftClient warcraftClient = new WarcraftClient(_apiKey);
             RequestResult<IList<Challenge>> result = await warcraftClient.GetChallengesAsync();
             Assert.NotNull(result.Value);
         }
@@ -77,7 +77,7 @@ namespace ArgentPonyWarcraftClient.Tests
         [Fact]
         public async void GetChallengesAsync_Gets_Challenges()
         {
-            var warcraftClient = new WarcraftClient(_apiKey);
+            IWarcraftClient warcraftClient = new WarcraftClient(_apiKey);
             RequestResult<IList<Challenge>> result = await warcraftClient.GetChallengesAsync("Norgannon");
             Assert.NotNull(result.Value);
         }
@@ -85,7 +85,7 @@ namespace ArgentPonyWarcraftClient.Tests
         [Fact]
         public async void GetCharacterAsync_Gets_Character()
         {
-            var warcraftClient = new WarcraftClient(_apiKey);
+            IWarcraftClient warcraftClient = new WarcraftClient(_apiKey);
             RequestResult<Character> result = await warcraftClient.GetCharacterAsync("Norgannon", "Drinian", CharacterFields.All);
             Assert.NotNull(result.Value);
         }
@@ -93,7 +93,7 @@ namespace ArgentPonyWarcraftClient.Tests
         [Fact]
         public async void GetCharacterClassesAsync_Gets_Character_Classes()
         {
-            var warcraftClient = new WarcraftClient(_apiKey);
+            IWarcraftClient warcraftClient = new WarcraftClient(_apiKey);
             RequestResult<IList<CharacterClassData>> result = await warcraftClient.GetCharacterClassesAsync();
             Assert.NotNull(result.Value);
             Assert.NotEmpty(result.Value);
@@ -102,7 +102,7 @@ namespace ArgentPonyWarcraftClient.Tests
         [Fact]
         public async void GetCharacterAchievementsAsync_Gets_Achievements()
         {
-            var warcraftClient = new WarcraftClient(_apiKey);
+            IWarcraftClient warcraftClient = new WarcraftClient(_apiKey);
             RequestResult<IList<AchievementCategory>> result = await warcraftClient.GetCharacterAchievementsAsync();
             Assert.NotNull(result.Value);
             Assert.NotEmpty(result.Value);
@@ -111,7 +111,7 @@ namespace ArgentPonyWarcraftClient.Tests
         [Fact]
         public async void GetCharacterRacesAsync_Gets_Character_Races()
         {
-            var warcraftClient = new WarcraftClient(_apiKey);
+            IWarcraftClient warcraftClient = new WarcraftClient(_apiKey);
             RequestResult<IList<CharacterRace>> result = await warcraftClient.GetCharacterRacesAsync();
             Assert.NotNull(result.Value);
             Assert.NotEmpty(result.Value);
@@ -120,7 +120,7 @@ namespace ArgentPonyWarcraftClient.Tests
         [Fact]
         public async void GetGuildAsync_Gets_Guild()
         {
-            var warcraftClient = new WarcraftClient(_apiKey);
+            IWarcraftClient warcraftClient = new WarcraftClient(_apiKey);
             RequestResult<Guild> result = await warcraftClient.GetGuildAsync("Norgannon", "Mythical Warriors", GuildFields.Challenge);
             Assert.NotNull(result.Value);
         }
@@ -128,7 +128,7 @@ namespace ArgentPonyWarcraftClient.Tests
         [Fact]
         public async void GetGuildAchievementsAsync_Gets_Guild_Achievements()
         {
-            var warcraftClient = new WarcraftClient(_apiKey);
+            IWarcraftClient warcraftClient = new WarcraftClient(_apiKey);
             RequestResult<IList<AchievementCategory>> result = await warcraftClient.GetGuildAchievementsAsync();
             Assert.NotNull(result.Value);
             Assert.NotEmpty(result.Value);
@@ -137,7 +137,7 @@ namespace ArgentPonyWarcraftClient.Tests
         [Fact]
         public async void GetGuildPerksAsync_Gets_Guild_Perks()
         {
-            var warcraftClient = new WarcraftClient(_apiKey);
+            IWarcraftClient warcraftClient = new WarcraftClient(_apiKey);
             RequestResult<IList<Perk>> result = await warcraftClient.GetGuildPerksAsync();
             Assert.NotNull(result.Value);
             Assert.NotEmpty(result.Value);
@@ -146,7 +146,7 @@ namespace ArgentPonyWarcraftClient.Tests
         [Fact]
         public async void GetGuildRewardsAsync_Gets_Guild_Rewards()
         {
-            var warcraftClient = new WarcraftClient(_apiKey);
+            IWarcraftClient warcraftClient = new WarcraftClient(_apiKey);
             RequestResult<IList<Reward>> result = await warcraftClient.GetGuildRewardsAsync();
             Assert.NotNull(result.Value);
             Assert.NotEmpty(result.Value);
@@ -155,7 +155,7 @@ namespace ArgentPonyWarcraftClient.Tests
         [Fact]
         public async void GetItemAsync_Gets_Item()
         {
-            var warcraftClient = new WarcraftClient(_apiKey);
+            IWarcraftClient warcraftClient = new WarcraftClient(_apiKey);
             RequestResult<Item> result = await warcraftClient.GetItemAsync(18803);
             Assert.NotNull(result.Value);
         }
@@ -163,7 +163,7 @@ namespace ArgentPonyWarcraftClient.Tests
         [Fact]
         public async void GetItemClassesAsync_Gets_Item_Classes()
         {
-            var warcraftClient = new WarcraftClient(_apiKey);
+            IWarcraftClient warcraftClient = new WarcraftClient(_apiKey);
             RequestResult<IList<ItemClass>> result = await warcraftClient.GetItemClassesAsync();
             Assert.NotNull(result.Value);
             Assert.NotEmpty(result.Value);
@@ -172,7 +172,7 @@ namespace ArgentPonyWarcraftClient.Tests
         [Fact]
         public async void GetItemSetAsync_Gets_Item_Set()
         {
-            var warcraftClient = new WarcraftClient(_apiKey);
+            IWarcraftClient warcraftClient = new WarcraftClient(_apiKey);
             RequestResult<ItemSet> result = await warcraftClient.GetItemSetAsync(1060);
             Assert.NotNull(result.Value);
         }
@@ -180,7 +180,7 @@ namespace ArgentPonyWarcraftClient.Tests
         [Fact]
         public async void GetMountsAsync_Gets_Mounts()
         {
-            var warcraftClient = new WarcraftClient(_apiKey);
+            IWarcraftClient warcraftClient = new WarcraftClient(_apiKey);
             RequestResult<IList<Mount>> result = await warcraftClient.GetMountsAsync();
             Assert.NotNull(result.Value);
             Assert.NotEmpty(result.Value);
@@ -189,7 +189,7 @@ namespace ArgentPonyWarcraftClient.Tests
         [Fact]
         public async void GetPetsAsync_Gets_Pets()
         {
-            var warcraftClient = new WarcraftClient(_apiKey);
+            IWarcraftClient warcraftClient = new WarcraftClient(_apiKey);
             RequestResult<IList<Pet>> result = await warcraftClient.GetPetsAsync();
             Assert.NotNull(result.Value);
             Assert.NotEmpty(result.Value);
@@ -198,7 +198,7 @@ namespace ArgentPonyWarcraftClient.Tests
         [Fact]
         public async void GetPetAbilityAsync_Gets_Pet_Ability()
         {
-            var warcraftClient = new WarcraftClient(_apiKey);
+            IWarcraftClient warcraftClient = new WarcraftClient(_apiKey);
             RequestResult<PetAbility> result = await warcraftClient.GetPetAbilityAsync(640);
             Assert.NotNull(result.Value);
         }
@@ -206,7 +206,7 @@ namespace ArgentPonyWarcraftClient.Tests
         [Fact]
         public async void GetPetSpeciesAsync_Gets_Pet_Species()
         {
-            var warcraftClient = new WarcraftClient(_apiKey);
+            IWarcraftClient warcraftClient = new WarcraftClient(_apiKey);
             RequestResult<PetSpecies> result = await warcraftClient.GetPetSpeciesAsync(258);
             Assert.NotNull(result.Value);
         }
@@ -214,7 +214,7 @@ namespace ArgentPonyWarcraftClient.Tests
         [Fact]
         public async void GetPetStatsAsync_Gets_Pet_Stats()
         {
-            var warcraftClient = new WarcraftClient(_apiKey);
+            IWarcraftClient warcraftClient = new WarcraftClient(_apiKey);
             RequestResult<PetStats> result = await warcraftClient.GetPetStatsAsync(258, 25, 5, BattlePetQuality.Epic);
             Assert.NotNull(result.Value);
         }
@@ -222,7 +222,7 @@ namespace ArgentPonyWarcraftClient.Tests
         [Fact]
         public async void GetPetTypesAsync_Gets_Pet_Types()
         {
-            var warcraftClient = new WarcraftClient(_apiKey);
+            IWarcraftClient warcraftClient = new WarcraftClient(_apiKey);
             RequestResult<IList<PetType>> result = await warcraftClient.GetPetTypesAsync();
             Assert.NotNull(result.Value);
             Assert.NotEmpty(result.Value);
@@ -231,7 +231,7 @@ namespace ArgentPonyWarcraftClient.Tests
         [Fact]
         public async void GetPvpLeaderboardAsync_Gets_Leaderboard()
         {
-            var warcraftClient = new WarcraftClient(_apiKey);
+            IWarcraftClient warcraftClient = new WarcraftClient(_apiKey);
             RequestResult<PvpLeaderboard> result = await warcraftClient.GetPvpLeaderboardAsync("2v2");
             Assert.NotNull(result.Value);
         }
@@ -239,7 +239,7 @@ namespace ArgentPonyWarcraftClient.Tests
         [Fact]
         public async void GetQuestAsync_Gets_Quest()
         {
-            var warcraftClient = new WarcraftClient(_apiKey);
+            IWarcraftClient warcraftClient = new WarcraftClient(_apiKey);
             RequestResult<Quest> result = await warcraftClient.GetQuestAsync(13146);
             Assert.NotNull(result.Value);
         }
@@ -247,7 +247,7 @@ namespace ArgentPonyWarcraftClient.Tests
         [Fact]
         public async void GetRealmsAsync_Gets_Realms()
         {
-            var warcraftClient = new WarcraftClient(_apiKey);
+            IWarcraftClient warcraftClient = new WarcraftClient(_apiKey);
             RequestResult<IList<Realm>> result = await warcraftClient.GetRealmStatusAsync();
             Assert.NotNull(result.Value);
             Assert.NotEmpty(result.Value);
@@ -256,7 +256,7 @@ namespace ArgentPonyWarcraftClient.Tests
         [Fact]
         public async void GetRecipe_Gets_Recipe()
         {
-            var warcraftClient = new WarcraftClient(_apiKey);
+            IWarcraftClient warcraftClient = new WarcraftClient(_apiKey);
             RequestResult<Recipe> result = await warcraftClient.GetRecipeAsync(33994);
             Assert.NotNull(result.Value);
         }
@@ -264,7 +264,7 @@ namespace ArgentPonyWarcraftClient.Tests
         [Fact]
         public async void GetSpellAsync_Gets_Spell()
         {
-            var warcraftClient = new WarcraftClient(_apiKey);
+            IWarcraftClient warcraftClient = new WarcraftClient(_apiKey);
             RequestResult<Spell> result = await warcraftClient.GetSpellAsync(79733);
             Assert.NotNull(result.Value);
         }
@@ -272,7 +272,7 @@ namespace ArgentPonyWarcraftClient.Tests
         [Fact]
         public async void GetTalentsAsync_Gets_Talents()
         {
-            var warcraftClient = new WarcraftClient(_apiKey);
+            IWarcraftClient warcraftClient = new WarcraftClient(_apiKey);
             RequestResult<IDictionary<CharacterClass, TalentSet>> result = await warcraftClient.GetTalentsAsync();
             Assert.NotNull(result.Value);
             Assert.NotEmpty(result.Value);
@@ -281,7 +281,7 @@ namespace ArgentPonyWarcraftClient.Tests
         [Fact]
         public async void GetZoneAsync_Gets_Zone()
         {
-            var warcraftClient = new WarcraftClient(_apiKey);
+            IWarcraftClient warcraftClient = new WarcraftClient(_apiKey);
             RequestResult<Zone> result = await warcraftClient.GetZoneAsync(4131);
             Assert.NotNull(result.Value);
         }
@@ -289,7 +289,7 @@ namespace ArgentPonyWarcraftClient.Tests
         [Fact]
         public async void GetZonesAsync_Gets_Zones()
         {
-            var warcraftClient = new WarcraftClient(_apiKey);
+            IWarcraftClient warcraftClient = new WarcraftClient(_apiKey);
             RequestResult<IList<Zone>> result = await warcraftClient.GetZonesAsync();
             Assert.NotEmpty(result.Value);
         }
@@ -297,7 +297,7 @@ namespace ArgentPonyWarcraftClient.Tests
         [Fact]
         public async void ProducesNotFoundError()
         {
-            var warcraftClient = new WarcraftClient(_apiKey);
+            IWarcraftClient warcraftClient = new WarcraftClient(_apiKey);
             RequestResult<Zone> result = await warcraftClient.GetZoneAsync(99999991);
             Assert.NotNull(result.Error);
             Assert.Equal("404", result.Error.Code);
@@ -308,7 +308,7 @@ namespace ArgentPonyWarcraftClient.Tests
         [Fact]
         public async void ProducesForbiddenError()
         {
-            var warcraftClient = new WarcraftClient("345knkl23n4lkn23623la");
+            IWarcraftClient warcraftClient = new WarcraftClient("345knkl23n4lkn23623la");
             RequestResult<Zone> result = await warcraftClient.GetZoneAsync(4131);
             Assert.NotNull(result.Error);
             Assert.Equal("403", result.Error.Code);

--- a/src/ArgentPonyWarcraftClient/IWarcraftClient.cs
+++ b/src/ArgentPonyWarcraftClient/IWarcraftClient.cs
@@ -1,0 +1,286 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    ///     A client for the World of Warcraft Community APIs.
+    /// </summary>
+    public interface IWarcraftClient
+    {
+        /// <summary>
+        ///     Get the specified achievement.
+        /// </summary>
+        /// <param name="id">The achievement ID.</param>
+        /// <returns>
+        ///     The specified achievement.
+        /// </returns>
+        Task<RequestResult<Achievement>> GetAchievementAsync(int id);
+
+        /// <summary>
+        ///     Get the specified achievement.
+        /// </summary>
+        /// <param name="id">The achievement ID.</param>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     The specified achievement.
+        /// </returns>
+        Task<RequestResult<Achievement>> GetAchievementAsync(int id, Region region, string locale);
+
+        /// <summary>
+        ///     Get the specified auction.
+        /// </summary>
+        /// <param name="realm">The realm.</param>
+        /// <returns>
+        ///     The specified auction.
+        /// </returns>
+        Task<RequestResult<AuctionFiles>> GetAuctionAsync(string realm);
+
+        /// <summary>
+        ///     Get the specified auction.
+        /// </summary>
+        /// <param name="realm">The realm.</param>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     The specified auction.
+        /// </returns>
+        Task<RequestResult<AuctionFiles>> GetAuctionAsync(string realm, Region region, string locale);
+
+        /// <summary>
+        ///     Get the auction house snapshot from the specified file.
+        /// </summary>
+        /// <param name="url">The URL for the auction house file.</param>
+        /// <returns>
+        ///     The auction house snapshot from the specified file.
+        /// </returns>
+        Task<RequestResult<AuctionHouseSnapshot>> GetAuctionHouseSnapshotAsync(string url);
+
+        /// <summary>
+        ///     Get a list of all supported battlegroups.
+        /// </summary>
+        /// <returns>
+        ///     A list of all supported battlegroups.
+        /// </returns>
+        Task<RequestResult<IList<Battlegroup>>> GetBattlegroupsAsync();
+
+        /// <summary>
+        ///     Get a list of all supported battlegroups.
+        /// </summary>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     A list of all supported battlegroups.
+        /// </returns>
+        Task<RequestResult<IList<Battlegroup>>> GetBattlegroupsAsync(Region region, string locale);
+
+        /// <summary>
+        ///     Get the specified boss.
+        /// </summary>
+        /// <remarks>
+        ///     A "boss" in this context should be considered a boss encounter, which may include more than one NPC.
+        /// </remarks>
+        /// <param name="id">The boss ID.</param>
+        /// <returns>
+        ///     The specified boss.
+        /// </returns>
+        Task<RequestResult<Boss>> GetBossAsync(int id);
+
+        /// <summary>
+        ///     Get the specified boss.
+        /// </summary>
+        /// <remarks>
+        ///     A "boss" in this context should be considered a boss encounter, which may include more than one NPC.
+        /// </remarks>
+        /// <param name="id">The boss ID.</param>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     The specified boss.
+        /// </returns>
+        Task<RequestResult<Boss>> GetBossAsync(int id, Region region, string locale);
+
+        /// <summary>
+        ///     Get a list of all supported bosses.
+        /// </summary>
+        /// <remarks>
+        ///     A "boss" in this context should be considered a boss encounter, which may include more than one NPC.
+        /// </remarks>
+        /// <returns>
+        ///     A list of all supported bosses.
+        /// </returns>
+        Task<RequestResult<IList<Boss>>> GetBossesAsync();
+
+        /// <summary>
+        ///     Get a list of all supported bosses.
+        /// </summary>
+        /// <remarks>
+        ///     A "boss" in this context should be considered a boss encounter, which may include more than one NPC.
+        /// </remarks>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     A list of all supported bosses.
+        /// </returns>
+        Task<RequestResult<IList<Boss>>> GetBossesAsync(Region region, string locale);
+
+        /// <summary>
+        ///     Get the challenge mode data for the entire region.
+        /// </summary>
+        /// <returns>
+        ///     The challenge mode data for the entire region.
+        /// </returns>
+        Task<RequestResult<IList<Challenge>>> GetChallengesAsync();
+
+        /// <summary>
+        ///     Get the challenge mode data for the entire region.
+        /// </summary>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     The challenge mode data for the entire region.
+        /// </returns>
+        Task<RequestResult<IList<Challenge>>> GetChallengesAsync(Region region, string locale);
+
+        /// <summary>
+        ///     Get the challenge mode data for the specified realm.
+        /// </summary>
+        /// <param name="realm">The realm.</param>
+        /// <returns>
+        ///     The challenge mode data for the specified realm.
+        /// </returns>
+        Task<RequestResult<IList<Challenge>>> GetChallengesAsync(string realm);
+
+        /// <summary>
+        ///     Get the challenge mode data for the specified realm.
+        /// </summary>
+        /// <param name="realm">The realm.</param>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     The challenge mode data for the specified realm.
+        /// </returns>
+        Task<RequestResult<IList<Challenge>>> GetChallengesAsync(string realm, Region region, string locale);
+
+        /// <summary>
+        ///     Get the specified character.
+        /// </summary>
+        /// <param name="realm">The realm.</param>
+        /// <param name="characterName">The character name.</param>
+        /// <param name="fields">The character fields to include.</param>
+        /// <returns>
+        ///     The specified character.
+        /// </returns>>
+        Task<RequestResult<Character>> GetCharacterAsync(string realm, string characterName, CharacterFields fields = CharacterFields.None);
+
+        /// <summary>
+        ///     Get the specified character.
+        /// </summary>
+        /// <param name="realm">The realm.</param>
+        /// <param name="characterName">The character name.</param>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <param name="fields">The character fields to include.</param>
+        /// <returns>
+        ///     The specified character.
+        /// </returns>
+        Task<RequestResult<Character>> GetCharacterAsync(string realm, string characterName, Region region, string locale, CharacterFields fields = CharacterFields.None);
+
+        /// <summary>
+        ///     Get a list of all of the achievements that characters can earn as well as the category structure and hierarchy.
+        /// </summary>
+        /// <returns>
+        ///     A list of all of the achievements that characters can earn as well as the category structure and hierarchy.
+        /// </returns>
+        Task<RequestResult<IList<AchievementCategory>>> GetCharacterAchievementsAsync();
+
+        /// <summary>
+        ///     Get a list of all of the achievements that characters can earn as well as the category structure and hierarchy.
+        /// </summary>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     A list of all of the achievements that characters can earn as well as the category structure and hierarchy.
+        /// </returns>
+        Task<RequestResult<IList<AchievementCategory>>> GetCharacterAchievementsAsync(Region region, string locale);
+
+        /// <summary>
+        ///     Get a list of all supported character classes.
+        /// </summary>
+        /// <returns>
+        ///     A list of all supported character classes.
+        /// </returns>
+        Task<RequestResult<IList<CharacterClassData>>> GetCharacterClassesAsync();
+
+        /// <summary>
+        /// Get a list of all supported character classes.
+        /// </summary>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        /// A list of all supported character classes.
+        /// </returns>
+        Task<RequestResult<IList<CharacterClassData>>> GetCharacterClassesAsync(Region region, string locale);
+
+        /// <summary>
+        ///     Get a list of all supported character races.
+        /// </summary>
+        /// <returns>
+        ///     A list of all supported character races.
+        /// </returns>
+        Task<RequestResult<IList<CharacterRace>>> GetCharacterRacesAsync();
+
+        /// <summary>
+        ///     Get a list of all supported character races.
+        /// </summary>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     A list of all supported character races.
+        /// </returns>
+        Task<RequestResult<IList<CharacterRace>>> GetCharacterRacesAsync(Region region, string locale);
+
+        /// <summary>
+        ///     Get the specified guild.
+        /// </summary>
+        /// <param name="realm">The realm.</param>
+        /// <param name="guildName">The guild name.</param>
+        /// <param name="fields">The guild fields to include.</param>
+        /// <returns>
+        ///     The specified guild.
+        /// </returns>
+        Task<RequestResult<Guild>> GetGuildAsync(string realm, string guildName, GuildFields fields = GuildFields.None);
+
+        /// <summary>
+        ///     Get the specified guild.
+        /// </summary>
+        /// <param name="realm">The realm.</param>
+        /// <param name="guildName">The guild name.</param>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <param name="fields">The guild fields to include.</param>
+        /// <returns>
+        ///     The specified guild.
+        /// </returns>
+        Task<RequestResult<Guild>> GetGuildAsync(string realm, string guildName, Region region, string locale, GuildFields fields = GuildFields.None);
+
+        /// <summary>
+        ///     Get a list of all guild achievements.
+        /// </summary>
+        /// <returns>
+        ///     A list of all guild achievements.
+        /// </returns>
+        Task<RequestResult<IList<AchievementCategory>>> GetGuildAchievementsAsync();
+
+        /// <summary>
+        ///     Get a list of all guild achievements.
+        /// </summary>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     A list of all guild achievements.
+        /// </returns>
+        Task<RequestResult<IList<AchievementCategory>>> GetGuildAchievementsAsync(Region region, string locale);
+    }
+}

--- a/src/ArgentPonyWarcraftClient/IWarcraftClient.cs
+++ b/src/ArgentPonyWarcraftClient/IWarcraftClient.cs
@@ -282,5 +282,363 @@ namespace ArgentPonyWarcraftClient
         ///     A list of all guild achievements.
         /// </returns>
         Task<RequestResult<IList<AchievementCategory>>> GetGuildAchievementsAsync(Region region, string locale);
+
+        /// <summary>
+        ///     Get a list of all guild perks.
+        /// </summary>
+        /// <returns>
+        ///     A list of all guild perks.
+        /// </returns>
+        Task<RequestResult<IList<Perk>>> GetGuildPerksAsync();
+
+        /// <summary>
+        ///     Get a list of all guild perks.
+        /// </summary>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     A list of all guild perks.
+        /// </returns>
+        Task<RequestResult<IList<Perk>>> GetGuildPerksAsync(Region region, string locale);
+
+        /// <summary>
+        ///     Get a list of all guild rewards.
+        /// </summary>
+        /// <returns>
+        ///     A list of all guild rewards.
+        /// </returns>
+        Task<RequestResult<IList<Reward>>> GetGuildRewardsAsync();
+
+        /// <summary>
+        ///     Get a list of all guild rewards.
+        /// </summary>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     A list of all guild rewards.
+        /// </returns>
+        Task<RequestResult<IList<Reward>>> GetGuildRewardsAsync(Region region, string locale);
+
+        /// <summary>
+        ///     Get the specified item.
+        /// </summary>
+        /// <param name="itemId">The item ID.</param>
+        /// <returns>
+        ///     The specified item.
+        /// </returns>
+        Task<RequestResult<Item>> GetItemAsync(int itemId);
+
+        /// <summary>
+        ///     Get the specified item.
+        /// </summary>
+        /// <param name="itemId">The item ID.</param>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     The specified item.
+        /// </returns>
+        Task<RequestResult<Item>> GetItemAsync(int itemId, Region region, string locale);
+
+        /// <summary>
+        ///     Get a list of all item classes.
+        /// </summary>
+        /// <returns>
+        ///     A list of all item classes.
+        /// </returns>
+        Task<RequestResult<IList<ItemClass>>> GetItemClassesAsync();
+
+        /// <summary>
+        ///     Get a list of all item classes.
+        /// </summary>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     A list of all item classes.
+        /// </returns>
+        Task<RequestResult<IList<ItemClass>>> GetItemClassesAsync(Region region, string locale);
+
+        /// <summary>
+        ///     Get the specified item set.
+        /// </summary>
+        /// <param name="itemSetId">The item set ID.</param>
+        /// <returns>
+        ///     The specified item set.
+        /// </returns>
+        Task<RequestResult<ItemSet>> GetItemSetAsync(int itemSetId);
+
+        /// <summary>
+        ///     Get the specified item set.
+        /// </summary>
+        /// <param name="itemSetId">The item set ID.</param>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     The specified item set.
+        /// </returns>
+        Task<RequestResult<ItemSet>> GetItemSetAsync(int itemSetId, Region region, string locale);
+
+        /// <summary>
+        ///     Get a list of all supported mounts.
+        /// </summary>
+        /// <returns>
+        ///     A list of all supported mounts.
+        /// </returns>
+        Task<RequestResult<IList<Mount>>> GetMountsAsync();
+
+        /// <summary>
+        ///     Get a list of all supported pets.
+        /// </summary>
+        /// <returns>
+        ///     A list of all supported pets.
+        /// </returns>
+        Task<RequestResult<IList<Pet>>> GetPetsAsync();
+
+        /// <summary>
+        ///     Get a list of all supported pets.
+        /// </summary>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     A list of all supported pets.
+        /// </returns>
+        Task<RequestResult<IList<Pet>>> GetPetsAsync(Region region, string locale);
+
+        /// <summary>
+        ///     Get the specified pet ability.
+        /// </summary>
+        /// <param name="abilityId">The pet ability ID.</param>
+        /// <returns>
+        ///     The specified pet ability.
+        /// </returns>
+        Task<RequestResult<PetAbility>> GetPetAbilityAsync(int abilityId);
+
+        /// <summary>
+        ///     Get the specified pet ability.
+        /// </summary>
+        /// <param name="abilityId">The pet ability ID.</param>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     The specified pet ability.
+        /// </returns>
+        Task<RequestResult<PetAbility>> GetPetAbilityAsync(int abilityId, Region region, string locale);
+
+        /// <summary>
+        ///     Get the specified pet species.
+        /// </summary>
+        /// <param name="speciesId">The pet species ID.</param>
+        /// <returns>
+        ///     The specified pet species.
+        /// </returns>
+        Task<RequestResult<PetSpecies>> GetPetSpeciesAsync(int speciesId);
+
+        /// <summary>
+        ///     Get the specified pet species.
+        /// </summary>
+        /// <param name="speciesId">The pet species ID.</param>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     The specified pet species.
+        /// </returns>
+        Task<RequestResult<PetSpecies>> GetPetSpeciesAsync(int speciesId, Region region, string locale);
+
+        /// <summary>
+        ///     Get the pet stats for the specified pet species, level, breed, and quality.
+        /// </summary>
+        /// <param name="speciesId">The pet species ID.</param>
+        /// <param name="level">The pet level.</param>
+        /// <param name="breedId">The breed ID.</param>
+        /// <param name="quality">The quality.</param>
+        /// <returns>
+        ///     The pet stats for the specified pet species, level, breed, and quality.
+        /// </returns>
+        Task<RequestResult<PetStats>> GetPetStatsAsync(int speciesId, int level, int breedId, BattlePetQuality quality);
+
+        /// <summary>
+        ///     Get the pet stats for the specified pet species, level, breed, and quality.
+        /// </summary>
+        /// <param name="speciesId">The pet species ID.</param>
+        /// <param name="level">The pet level.</param>
+        /// <param name="breedId">The breed ID.</param>
+        /// <param name="quality">The quality.</param>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     The pet stats for the specified pet species, level, breed, and quality.
+        /// </returns>
+        Task<RequestResult<PetStats>> GetPetStatsAsync(int speciesId, int level, int breedId, BattlePetQuality quality, Region region, string locale);
+
+        /// <summary>
+        ///     Get a list of all pet types.
+        /// </summary>
+        /// <returns>
+        ///     A list of all pet types.
+        /// </returns>
+        Task<RequestResult<IList<PetType>>> GetPetTypesAsync();
+
+        /// <summary>
+        ///     Get a list of all pet types.
+        /// </summary>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     A list of all pet types.
+        /// </returns>
+        Task<RequestResult<IList<PetType>>> GetPetTypesAsync(Region region, string locale);
+
+        /// <summary>
+        ///     Get the PvP leaderboard for the specified bracket.
+        /// </summary>
+        /// <param name="bracket">The PvP leaderboard bracket.  Valid entries are 2v2, 3v3, 5v5, and rbg.</param>
+        /// <returns>
+        ///     The PvP leaderboard for the specified bracket.
+        /// </returns>
+        Task<RequestResult<PvpLeaderboard>> GetPvpLeaderboardAsync(string bracket);
+
+        /// <summary>
+        ///     Get the PvP leaderboard for the specified bracket.
+        /// </summary>
+        /// <param name="bracket">The PvP leaderboard bracket.  Valid entries are 2v2, 3v3, 5v5, and rbg.</param>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     The PvP leaderboard for the specified bracket.
+        /// </returns>
+        Task<RequestResult<PvpLeaderboard>> GetPvpLeaderboardAsync(string bracket, Region region, string locale);
+
+        /// <summary>
+        ///     Get the specified quest.
+        /// </summary>
+        /// <param name="questId">The quest ID.</param>
+        /// <returns>
+        ///     The specified quest.
+        /// </returns>
+        Task<RequestResult<Quest>> GetQuestAsync(int questId);
+
+        /// <summary>
+        ///     Get the specified quest.
+        /// </summary>
+        /// <param name="questId">The quest ID.</param>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     The specified quest.
+        /// </returns>
+        Task<RequestResult<Quest>> GetQuestAsync(int questId, Region region, string locale);
+
+        /// <summary>
+        ///     Get the statuses for all realms.
+        /// </summary>
+        /// <returns>
+        ///     The statuses for all realms.
+        /// </returns>
+        Task<RequestResult<IList<Realm>>> GetRealmStatusAsync();
+
+        /// <summary>
+        ///     Get the statuses for all realms.
+        /// </summary>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     The statuses for all realms.
+        /// </returns>
+        Task<RequestResult<IList<Realm>>> GetRealmStatusAsync(Region region, string locale);
+
+        /// <summary>
+        ///     Get the specified recipe.
+        /// </summary>
+        /// <param name="recipeId">The recipe ID.</param>
+        /// <returns>
+        ///     The specified recipe.
+        /// </returns>
+        Task<RequestResult<Recipe>> GetRecipeAsync(int recipeId);
+
+        /// <summary>
+        ///     Get the specified recipe.
+        /// </summary>
+        /// <param name="recipeId">The recipe ID.</param>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     The specified recipe.
+        /// </returns>
+        Task<RequestResult<Recipe>> GetRecipeAsync(int recipeId, Region region, string locale);
+
+        /// <summary>
+        ///     Get the specified spell.
+        /// </summary>
+        /// <param name="spellId">The spell ID.</param>
+        /// <returns>
+        ///     The specified spell.
+        /// </returns>
+        Task<RequestResult<Spell>> GetSpellAsync(int spellId);
+
+        /// <summary>
+        ///     Get the specified spell.
+        /// </summary>
+        /// <param name="spellId">The spell ID.</param>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     The specified spell.
+        /// </returns>
+        Task<RequestResult<Spell>> GetSpellAsync(int spellId, Region region, string locale);
+
+        /// <summary>
+        ///     Get a dictionary of talents, indexed by character class.
+        /// </summary>
+        /// <returns>
+        ///     A dictionary of talents, indexed by character class.
+        /// </returns>
+        Task<RequestResult<IDictionary<CharacterClass, TalentSet>>> GetTalentsAsync();
+
+        /// <summary>
+        ///     Get a dictionary of talents, indexed by character class.
+        /// </summary>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     A dictionary of talents, indexed by character class.
+        /// </returns>
+        Task<RequestResult<IDictionary<CharacterClass, TalentSet>>> GetTalentsAsync(Region region, string locale);
+
+        /// <summary>
+        ///     Get the specified zone.
+        /// </summary>
+        /// <param name="zoneId">The zone ID.</param>
+        /// <returns>
+        ///     The specified zone.
+        /// </returns>
+        Task<RequestResult<Zone>> GetZoneAsync(int zoneId);
+
+        /// <summary>
+        ///     Get the specified zone.
+        /// </summary>
+        /// <param name="zoneId">The zone ID.</param>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     The specified zone.
+        /// </returns>
+        Task<RequestResult<Zone>> GetZoneAsync(int zoneId, Region region, string locale);
+
+        /// <summary>
+        ///     Get a list of all supported zones.
+        /// </summary>
+        /// <returns>
+        ///     A list of all supported zones.
+        /// </returns>
+        Task<RequestResult<IList<Zone>>> GetZonesAsync();
+
+        /// <summary>
+        ///     Get a list of all supported zones.
+        /// </summary>
+        /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
+        /// <param name="locale">Specifies the language that the result will be in.</param>
+        /// <returns>
+        ///     A list of all supported zones.
+        /// </returns>
+        Task<RequestResult<IList<Zone>>> GetZonesAsync(Region region, string locale);
     }
 }

--- a/src/ArgentPonyWarcraftClient/WarcraftClient.cs
+++ b/src/ArgentPonyWarcraftClient/WarcraftClient.cs
@@ -11,7 +11,7 @@ namespace ArgentPonyWarcraftClient
     /// <summary>
     ///     A client for the World of Warcraft Community APIs.
     /// </summary>
-    public class WarcraftClient
+    public class WarcraftClient : IWarcraftClient
     {
         private readonly HttpClient _client;
         private readonly string _apiKey;


### PR DESCRIPTION
Created an `IWarcraftClient` interface to allow support for mocking the client in unit tests. I also updated the unit tests to explicitly use the `IWarcraftClient` interface to verify that none of the original methods were missed.

Closes #50 