### PR TITLE
Add locale enum type

### DIFF
--- a/src/ArgentPonyWarcraftClient.Tests/WarcraftClientTests.cs
+++ b/src/ArgentPonyWarcraftClient.Tests/WarcraftClientTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -36,7 +37,7 @@ namespace ArgentPonyWarcraftClient.Tests
             IWarcraftClient warcraftClient = new WarcraftClient(
                 apiKey: "keyhere",
                 region: Region.US,
-                locale: "en_US",
+                locale: Locale.en_US,
                 client: mockHttp.ToHttpClient());
 
             //IWarcraftClient warcraftClient = new WarcraftClient(_apiKey);
@@ -421,6 +422,15 @@ namespace ArgentPonyWarcraftClient.Tests
             Assert.Null(result.Value);
         }
 
+        [Fact]
+        public void Throws_ArgumentException_Invaild_Region_Locale()
+        {
+            Assert.Throws<ArgumentException>(() =>
+            {
+                IWarcraftClient client = new WarcraftClient("APIKEY", Region.Korea, Locale.fr_FR);
+            });
+        }
+
         private static IWarcraftClient BuildMockClient(string requestUri, string responseContent)
         {
             var mockHttp = new MockHttpMessageHandler();
@@ -432,7 +442,7 @@ namespace ArgentPonyWarcraftClient.Tests
             return new WarcraftClient(
                 apiKey: "keyhere",
                 region: Region.US,
-                locale: "en_US",
+                locale: Locale.en_US,
                 client: mockHttp.ToHttpClient());
         }
 
@@ -450,7 +460,7 @@ namespace ArgentPonyWarcraftClient.Tests
             return new WarcraftClient(
                 apiKey: "keyhere",
                 region: Region.US,
-                locale: "en_US",
+                locale: Locale.en_US,
                 client: mockHttp.ToHttpClient());
         }
     }

--- a/src/ArgentPonyWarcraftClient/ArgentPonyWarcraftClient.csproj
+++ b/src/ArgentPonyWarcraftClient/ArgentPonyWarcraftClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFramework>netstandard1.5</TargetFramework>
     <PackageId>ArgentPonyWarcraftClient</PackageId>
     <PackageVersion>1.0.0</PackageVersion>
     <Authors>Dan Jagnow, Travis Boatman</Authors>
@@ -33,6 +33,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/ArgentPonyWarcraftClient/IWarcraftClient.cs
+++ b/src/ArgentPonyWarcraftClient/IWarcraftClient.cs
@@ -26,7 +26,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The specified achievement.
         /// </returns>
-        Task<RequestResult<Achievement>> GetAchievementAsync(int id, Region region, string locale);
+        Task<RequestResult<Achievement>> GetAchievementAsync(int id, Region region, Locale locale);
 
         /// <summary>
         ///     Get the specified auction.
@@ -46,7 +46,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The specified auction.
         /// </returns>
-        Task<RequestResult<AuctionFiles>> GetAuctionAsync(string realm, Region region, string locale);
+        Task<RequestResult<AuctionFiles>> GetAuctionAsync(string realm, Region region, Locale locale);
 
         /// <summary>
         ///     Get the auction house snapshot from the specified file.
@@ -73,7 +73,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     A list of all supported battlegroups.
         /// </returns>
-        Task<RequestResult<IList<Battlegroup>>> GetBattlegroupsAsync(Region region, string locale);
+        Task<RequestResult<IList<Battlegroup>>> GetBattlegroupsAsync(Region region, Locale locale);
 
         /// <summary>
         ///     Get the specified boss.
@@ -99,7 +99,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The specified boss.
         /// </returns>
-        Task<RequestResult<Boss>> GetBossAsync(int id, Region region, string locale);
+        Task<RequestResult<Boss>> GetBossAsync(int id, Region region, Locale locale);
 
         /// <summary>
         ///     Get a list of all supported bosses.
@@ -123,7 +123,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     A list of all supported bosses.
         /// </returns>
-        Task<RequestResult<IList<Boss>>> GetBossesAsync(Region region, string locale);
+        Task<RequestResult<IList<Boss>>> GetBossesAsync(Region region, Locale locale);
 
         /// <summary>
         ///     Get the challenge mode data for the entire region.
@@ -141,7 +141,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The challenge mode data for the entire region.
         /// </returns>
-        Task<RequestResult<IList<Challenge>>> GetChallengesAsync(Region region, string locale);
+        Task<RequestResult<IList<Challenge>>> GetChallengesAsync(Region region, Locale locale);
 
         /// <summary>
         ///     Get the challenge mode data for the specified realm.
@@ -161,7 +161,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The challenge mode data for the specified realm.
         /// </returns>
-        Task<RequestResult<IList<Challenge>>> GetChallengesAsync(string realm, Region region, string locale);
+        Task<RequestResult<IList<Challenge>>> GetChallengesAsync(string realm, Region region, Locale locale);
 
         /// <summary>
         ///     Get the specified character.
@@ -185,7 +185,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The specified character.
         /// </returns>
-        Task<RequestResult<Character>> GetCharacterAsync(string realm, string characterName, Region region, string locale, CharacterFields fields = CharacterFields.None);
+        Task<RequestResult<Character>> GetCharacterAsync(string realm, string characterName, Region region, Locale locale, CharacterFields fields = CharacterFields.None);
 
         /// <summary>
         ///     Get a list of all of the achievements that characters can earn as well as the category structure and hierarchy.
@@ -203,7 +203,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     A list of all of the achievements that characters can earn as well as the category structure and hierarchy.
         /// </returns>
-        Task<RequestResult<IList<AchievementCategory>>> GetCharacterAchievementsAsync(Region region, string locale);
+        Task<RequestResult<IList<AchievementCategory>>> GetCharacterAchievementsAsync(Region region, Locale locale);
 
         /// <summary>
         ///     Get a list of all supported character classes.
@@ -221,7 +221,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         /// A list of all supported character classes.
         /// </returns>
-        Task<RequestResult<IList<CharacterClassData>>> GetCharacterClassesAsync(Region region, string locale);
+        Task<RequestResult<IList<CharacterClassData>>> GetCharacterClassesAsync(Region region, Locale locale);
 
         /// <summary>
         ///     Get a list of all supported character races.
@@ -239,7 +239,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     A list of all supported character races.
         /// </returns>
-        Task<RequestResult<IList<CharacterRace>>> GetCharacterRacesAsync(Region region, string locale);
+        Task<RequestResult<IList<CharacterRace>>> GetCharacterRacesAsync(Region region, Locale locale);
 
         /// <summary>
         ///     Get the specified guild.
@@ -263,7 +263,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The specified guild.
         /// </returns>
-        Task<RequestResult<Guild>> GetGuildAsync(string realm, string guildName, Region region, string locale, GuildFields fields = GuildFields.None);
+        Task<RequestResult<Guild>> GetGuildAsync(string realm, string guildName, Region region, Locale locale, GuildFields fields = GuildFields.None);
 
         /// <summary>
         ///     Get a list of all guild achievements.
@@ -281,7 +281,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     A list of all guild achievements.
         /// </returns>
-        Task<RequestResult<IList<AchievementCategory>>> GetGuildAchievementsAsync(Region region, string locale);
+        Task<RequestResult<IList<AchievementCategory>>> GetGuildAchievementsAsync(Region region, Locale locale);
 
         /// <summary>
         ///     Get a list of all guild perks.
@@ -299,7 +299,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     A list of all guild perks.
         /// </returns>
-        Task<RequestResult<IList<Perk>>> GetGuildPerksAsync(Region region, string locale);
+        Task<RequestResult<IList<Perk>>> GetGuildPerksAsync(Region region, Locale locale);
 
         /// <summary>
         ///     Get a list of all guild rewards.
@@ -317,7 +317,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     A list of all guild rewards.
         /// </returns>
-        Task<RequestResult<IList<Reward>>> GetGuildRewardsAsync(Region region, string locale);
+        Task<RequestResult<IList<Reward>>> GetGuildRewardsAsync(Region region, Locale locale);
 
         /// <summary>
         ///     Get the specified item.
@@ -337,7 +337,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The specified item.
         /// </returns>
-        Task<RequestResult<Item>> GetItemAsync(int itemId, Region region, string locale);
+        Task<RequestResult<Item>> GetItemAsync(int itemId, Region region, Locale locale);
 
         /// <summary>
         ///     Get a list of all item classes.
@@ -355,7 +355,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     A list of all item classes.
         /// </returns>
-        Task<RequestResult<IList<ItemClass>>> GetItemClassesAsync(Region region, string locale);
+        Task<RequestResult<IList<ItemClass>>> GetItemClassesAsync(Region region, Locale locale);
 
         /// <summary>
         ///     Get the specified item set.
@@ -375,7 +375,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The specified item set.
         /// </returns>
-        Task<RequestResult<ItemSet>> GetItemSetAsync(int itemSetId, Region region, string locale);
+        Task<RequestResult<ItemSet>> GetItemSetAsync(int itemSetId, Region region, Locale locale);
 
         /// <summary>
         ///     Get a list of all supported mounts.
@@ -401,7 +401,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     A list of all supported pets.
         /// </returns>
-        Task<RequestResult<IList<Pet>>> GetPetsAsync(Region region, string locale);
+        Task<RequestResult<IList<Pet>>> GetPetsAsync(Region region, Locale locale);
 
         /// <summary>
         ///     Get the specified pet ability.
@@ -421,7 +421,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The specified pet ability.
         /// </returns>
-        Task<RequestResult<PetAbility>> GetPetAbilityAsync(int abilityId, Region region, string locale);
+        Task<RequestResult<PetAbility>> GetPetAbilityAsync(int abilityId, Region region, Locale locale);
 
         /// <summary>
         ///     Get the specified pet species.
@@ -441,7 +441,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The specified pet species.
         /// </returns>
-        Task<RequestResult<PetSpecies>> GetPetSpeciesAsync(int speciesId, Region region, string locale);
+        Task<RequestResult<PetSpecies>> GetPetSpeciesAsync(int speciesId, Region region, Locale locale);
 
         /// <summary>
         ///     Get the pet stats for the specified pet species, level, breed, and quality.
@@ -467,7 +467,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The pet stats for the specified pet species, level, breed, and quality.
         /// </returns>
-        Task<RequestResult<PetStats>> GetPetStatsAsync(int speciesId, int level, int breedId, BattlePetQuality quality, Region region, string locale);
+        Task<RequestResult<PetStats>> GetPetStatsAsync(int speciesId, int level, int breedId, BattlePetQuality quality, Region region, Locale locale);
 
         /// <summary>
         ///     Get a list of all pet types.
@@ -485,7 +485,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     A list of all pet types.
         /// </returns>
-        Task<RequestResult<IList<PetType>>> GetPetTypesAsync(Region region, string locale);
+        Task<RequestResult<IList<PetType>>> GetPetTypesAsync(Region region, Locale locale);
 
         /// <summary>
         ///     Get the PvP leaderboard for the specified bracket.
@@ -505,7 +505,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The PvP leaderboard for the specified bracket.
         /// </returns>
-        Task<RequestResult<PvpLeaderboard>> GetPvpLeaderboardAsync(string bracket, Region region, string locale);
+        Task<RequestResult<PvpLeaderboard>> GetPvpLeaderboardAsync(string bracket, Region region, Locale locale);
 
         /// <summary>
         ///     Get the specified quest.
@@ -525,7 +525,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The specified quest.
         /// </returns>
-        Task<RequestResult<Quest>> GetQuestAsync(int questId, Region region, string locale);
+        Task<RequestResult<Quest>> GetQuestAsync(int questId, Region region, Locale locale);
 
         /// <summary>
         ///     Get the statuses for all realms.
@@ -543,7 +543,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The statuses for all realms.
         /// </returns>
-        Task<RequestResult<IList<Realm>>> GetRealmStatusAsync(Region region, string locale);
+        Task<RequestResult<IList<Realm>>> GetRealmStatusAsync(Region region, Locale locale);
 
         /// <summary>
         ///     Get the specified recipe.
@@ -563,7 +563,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The specified recipe.
         /// </returns>
-        Task<RequestResult<Recipe>> GetRecipeAsync(int recipeId, Region region, string locale);
+        Task<RequestResult<Recipe>> GetRecipeAsync(int recipeId, Region region, Locale locale);
 
         /// <summary>
         ///     Get the specified spell.
@@ -583,7 +583,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The specified spell.
         /// </returns>
-        Task<RequestResult<Spell>> GetSpellAsync(int spellId, Region region, string locale);
+        Task<RequestResult<Spell>> GetSpellAsync(int spellId, Region region, Locale locale);
 
         /// <summary>
         ///     Get a dictionary of talents, indexed by character class.
@@ -601,7 +601,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     A dictionary of talents, indexed by character class.
         /// </returns>
-        Task<RequestResult<IDictionary<CharacterClass, TalentSet>>> GetTalentsAsync(Region region, string locale);
+        Task<RequestResult<IDictionary<CharacterClass, TalentSet>>> GetTalentsAsync(Region region, Locale locale);
 
         /// <summary>
         ///     Get the specified zone.
@@ -621,7 +621,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The specified zone.
         /// </returns>
-        Task<RequestResult<Zone>> GetZoneAsync(int zoneId, Region region, string locale);
+        Task<RequestResult<Zone>> GetZoneAsync(int zoneId, Region region, Locale locale);
 
         /// <summary>
         ///     Get a list of all supported zones.
@@ -639,6 +639,6 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     A list of all supported zones.
         /// </returns>
-        Task<RequestResult<IList<Zone>>> GetZonesAsync(Region region, string locale);
+        Task<RequestResult<IList<Zone>>> GetZonesAsync(Region region, Locale locale);
     }
 }

--- a/src/ArgentPonyWarcraftClient/Models/Locale.cs
+++ b/src/ArgentPonyWarcraftClient/Models/Locale.cs
@@ -1,0 +1,86 @@
+﻿namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    ///     Represents the different locales supported by the Blizzard API.
+    /// </summary>
+    public enum Locale
+    {
+        /// <summary>
+        ///     English (United States of America)
+        /// </summary>
+        [LocaleRegion(Region.US)]
+        en_US,
+        
+        /// <summary>
+        ///     Spanish (Mexico)
+        /// </summary>
+        [LocaleRegion(Region.US)]
+        es_MX,
+
+        /// <summary>
+        ///     Portuguese (Brazil)
+        /// </summary>
+        [LocaleRegion(Region.US)]
+        pt_BR,
+
+        /// <summary>
+        ///     English (United Kingdom)
+        /// </summary>
+        [LocaleRegion(Region.Europe)]
+        en_GB,
+
+        /// <summary>
+        ///     Spanish (Spain)
+        /// </summary>
+        [LocaleRegion(Region.Europe)]
+        es_ES,
+
+        /// <summary>
+        ///     French (France)
+        /// </summary>
+        [LocaleRegion(Region.Europe)]
+        fr_FR,
+
+        /// <summary>
+        ///     Russian (Russian Federation)
+        /// </summary>
+        [LocaleRegion(Region.Europe)]
+        ru_RU,
+
+        /// <summary>
+        ///     German (Germany)
+        /// </summary>
+        [LocaleRegion(Region.Europe)]
+        de_DE,
+
+        /// <summary>
+        ///     Portuguese (Portugal)
+        /// </summary>
+        [LocaleRegion(Region.Europe)]
+        pt_PT,
+
+        /// <summary>
+        ///     Italian (Italy)
+        /// </summary>
+        [LocaleRegion(Region.Europe)]
+        it_IT,
+
+        /// <summary>
+        ///     Korean (Korea)
+        /// </summary>
+        [LocaleRegion(Region.Korea)]
+        ko_KR,
+
+        /// <summary>
+        ///     Chinese (Taiwan)
+        /// </summary>
+        [LocaleRegion(Region.Taiwan)]
+        zh_TW,
+
+        /// <summary>
+        ///     Chinese (China)
+        /// </summary>
+        [LocaleRegion(Region.China)]
+        zh_CN
+    }
+}

--- a/src/ArgentPonyWarcraftClient/Models/LocaleRegion.cs
+++ b/src/ArgentPonyWarcraftClient/Models/LocaleRegion.cs
@@ -1,0 +1,23 @@
+﻿using System;
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    ///     Used to set a valid region for a locale.
+    /// </summary>
+    public class LocaleRegion : Attribute
+    {
+        /// <summary>
+        ///     Sets a valid region for a locale.
+        /// </summary>
+        /// <param name="region">The selected region.</param>
+        public LocaleRegion(Region region)
+        {
+            Region = region;
+        }
+
+        /// <summary>
+        ///     Sets the region of the region.
+        /// </summary>
+        public Region Region { get; }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/WarcraftClient.cs
+++ b/src/ArgentPonyWarcraftClient/WarcraftClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Reflection;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -15,7 +16,7 @@ namespace ArgentPonyWarcraftClient
         private readonly HttpClient _client;
         private readonly string _apiKey;
         private readonly Region _region;
-        private readonly string _locale;
+        private readonly Locale _locale;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="WarcraftClient"/> class.
@@ -24,7 +25,7 @@ namespace ArgentPonyWarcraftClient
         ///     Defaults the region to US and the locale to "en_US".
         /// </remarks>
         /// <param name="apiKey">The API key.</param>
-        public WarcraftClient(string apiKey) : this(apiKey, Region.US, "en_US")
+        public WarcraftClient(string apiKey) : this(apiKey, Region.US, Locale.en_US)
         {
         }
 
@@ -37,7 +38,7 @@ namespace ArgentPonyWarcraftClient
         ///     Specifies the language that the result will be in. Visit
         ///     https://dev.battle.net/docs/read/community_apis to see a list of available locales.
         /// </param>
-        public WarcraftClient(string apiKey, Region region, string locale) : this (apiKey, region, locale, InternalHttpClient.Instance)
+        public WarcraftClient(string apiKey, Region region, Locale locale) : this (apiKey, region, locale, InternalHttpClient.Instance)
         {
         }
 
@@ -51,10 +52,16 @@ namespace ArgentPonyWarcraftClient
         ///     https://dev.battle.net/docs/read/community_apis to see a list of available locales.
         /// </param>
         /// <param name="client">The <see cref="HttpClient"/> that communicates with Blizzard.</param>
-        public WarcraftClient(string apiKey, Region region, string locale, HttpClient client)
+        public WarcraftClient(string apiKey, Region region, Locale locale, HttpClient client)
         {
             _client = client ?? throw new ArgumentNullException(nameof(client));
             _apiKey = apiKey ?? throw new ArgumentNullException(nameof(apiKey));
+
+            if (!ValidateRegionLocale(locale, region))
+            {
+                throw new ArgumentException("The locale selected is not supported by the selected region.");
+            }
+
             _region = region;
             _locale = locale;
         }
@@ -80,7 +87,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The specified achievement.
         /// </returns>
-        public async Task<RequestResult<Achievement>> GetAchievementAsync(int id, Region region, string locale)
+        public async Task<RequestResult<Achievement>> GetAchievementAsync(int id, Region region, Locale locale)
         {
             string host = GetHost(region);
             return await Get<Achievement>($"{host}/wow/achievement/{id}?locale={locale}&apikey={_apiKey}");
@@ -107,7 +114,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The specified auction.
         /// </returns>
-        public async Task<RequestResult<AuctionFiles>> GetAuctionAsync(string realm, Region region, string locale)
+        public async Task<RequestResult<AuctionFiles>> GetAuctionAsync(string realm, Region region, Locale locale)
         {
             string host = GetHost(region);
             return await Get<AuctionFiles>($"{host}/wow/auction/data/{realm}?locale={locale}&apikey={_apiKey}");
@@ -144,7 +151,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     A list of all supported battlegroups.
         /// </returns>
-        public async Task<RequestResult<IList<Battlegroup>>> GetBattlegroupsAsync(Region region, string locale)
+        public async Task<RequestResult<IList<Battlegroup>>> GetBattlegroupsAsync(Region region, Locale locale)
         {
             string host = GetHost(region);
             RequestResult<IList<Battlegroup>> battlegroupList = await Get<IList<Battlegroup>>($"{host}/wow/data/battlegroups/?locale={locale}&apikey={_apiKey}", "battlegroups");
@@ -179,7 +186,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The specified boss.
         /// </returns>
-        public async Task<RequestResult<Boss>> GetBossAsync(int id, Region region, string locale)
+        public async Task<RequestResult<Boss>> GetBossAsync(int id, Region region, Locale locale)
         {
             string host = GetHost(region);
             return await Get<Boss>($"{host}/wow/boss/{id}?locale={locale}&apikey={_apiKey}");
@@ -210,7 +217,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     A list of all supported bosses.
         /// </returns>
-        public async Task<RequestResult<IList<Boss>>> GetBossesAsync(Region region, string locale)
+        public async Task<RequestResult<IList<Boss>>> GetBossesAsync(Region region, Locale locale)
         {
             string host = GetHost(region);
             RequestResult<IList<Boss>> bossList = await Get<IList<Boss>>($"{host}/wow/boss/?locale={locale}&apikey={_apiKey}", "bosses");
@@ -236,7 +243,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The challenge mode data for the entire region.
         /// </returns>
-        public async Task<RequestResult<IList<Challenge>>> GetChallengesAsync(Region region, string locale)
+        public async Task<RequestResult<IList<Challenge>>> GetChallengesAsync(Region region, Locale locale)
         {
             string host = GetHost(region);
             RequestResult<IList<Challenge>> challengeList = await Get<IList<Challenge>>($"{host}/wow/challenge/region?locale={locale}&apikey={_apiKey}", "challenge");
@@ -264,7 +271,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The challenge mode data for the specified realm.
         /// </returns>
-        public async Task<RequestResult<IList<Challenge>>> GetChallengesAsync(string realm, Region region, string locale)
+        public async Task<RequestResult<IList<Challenge>>> GetChallengesAsync(string realm, Region region, Locale locale)
         {
             string host = GetHost(region);
             RequestResult<IList<Challenge>> challengeList = await Get<IList<Challenge>>($"{host}/wow/challenge/{realm}?locale={locale}&apikey={_apiKey}", "challenge");
@@ -296,7 +303,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The specified character.
         /// </returns>
-        public async Task<RequestResult<Character>> GetCharacterAsync(string realm, string characterName, Region region, string locale, CharacterFields fields = CharacterFields.None)
+        public async Task<RequestResult<Character>> GetCharacterAsync(string realm, string characterName, Region region, Locale locale, CharacterFields fields = CharacterFields.None)
         {
             string host = GetHost(region);
             string queryStringFields = fields.BuildQueryString();
@@ -322,7 +329,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     A list of all of the achievements that characters can earn as well as the category structure and hierarchy.
         /// </returns>
-        public async Task<RequestResult<IList<AchievementCategory>>> GetCharacterAchievementsAsync(Region region, string locale)
+        public async Task<RequestResult<IList<AchievementCategory>>> GetCharacterAchievementsAsync(Region region, Locale locale)
         {
             string host = GetHost(region);
             RequestResult<IList<AchievementCategory>> achievementList = await Get<IList<AchievementCategory>>($"{host}/wow/data/character/achievements?locale={locale}&apikey={_apiKey}", "achievements");
@@ -348,7 +355,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         /// A list of all supported character classes.
         /// </returns>
-        public async Task<RequestResult<IList<CharacterClassData>>> GetCharacterClassesAsync(Region region, string locale)
+        public async Task<RequestResult<IList<CharacterClassData>>> GetCharacterClassesAsync(Region region, Locale locale)
         {
             string host = GetHost(region);
             RequestResult<IList<CharacterClassData>> characterClassList = await Get<IList<CharacterClassData>>($"{host}/wow/data/character/classes?locale={locale}&apikey={_apiKey}", "classes");
@@ -374,7 +381,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     A list of all supported character races.
         /// </returns>
-        public async Task<RequestResult<IList<CharacterRace>>> GetCharacterRacesAsync(Region region, string locale)
+        public async Task<RequestResult<IList<CharacterRace>>> GetCharacterRacesAsync(Region region, Locale locale)
         {
             string host = GetHost(region);
             RequestResult<IList<CharacterRace>> characterRaceList = await Get<IList<CharacterRace>>($"{host}/wow/data/character/races?locale={locale}&apikey={_apiKey}", "races");
@@ -406,7 +413,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The specified guild.
         /// </returns>
-        public async Task<RequestResult<Guild>> GetGuildAsync(string realm, string guildName, Region region, string locale, GuildFields fields = GuildFields.None)
+        public async Task<RequestResult<Guild>> GetGuildAsync(string realm, string guildName, Region region, Locale locale, GuildFields fields = GuildFields.None)
         {
             string host = GetHost(region);
             string queryStringFields = fields.BuildQueryString();
@@ -432,7 +439,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     A list of all guild achievements.
         /// </returns>
-        public async Task<RequestResult<IList<AchievementCategory>>> GetGuildAchievementsAsync(Region region, string locale)
+        public async Task<RequestResult<IList<AchievementCategory>>> GetGuildAchievementsAsync(Region region, Locale locale)
         {
             string host = GetHost(region);
             RequestResult<IList<AchievementCategory>> guildAchievementsList = await Get<IList<AchievementCategory>>($"{host}/wow/data/guild/achievements?locale={locale}&apikey={_apiKey}", "achievements");
@@ -458,7 +465,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     A list of all guild perks.
         /// </returns>
-        public async Task<RequestResult<IList<Perk>>> GetGuildPerksAsync(Region region, string locale)
+        public async Task<RequestResult<IList<Perk>>> GetGuildPerksAsync(Region region, Locale locale)
         {
             string host = GetHost(region);
             RequestResult<IList<Perk>> guildPerksList = await Get<IList<Perk>>($"{host}/wow/data/guild/perks?locale={locale}&apikey={_apiKey}", "perks");
@@ -484,7 +491,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     A list of all guild rewards.
         /// </returns>
-        public async Task<RequestResult<IList<Reward>>> GetGuildRewardsAsync(Region region, string locale)
+        public async Task<RequestResult<IList<Reward>>> GetGuildRewardsAsync(Region region, Locale locale)
         {
             string host = GetHost(region);
             RequestResult<IList<Reward>> guildRewardsList = await Get<IList<Reward>>($"{host}/wow/data/guild/rewards?locale={locale}&apikey={_apiKey}", "rewards");
@@ -512,7 +519,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The specified item.
         /// </returns>
-        public async Task<RequestResult<Item>> GetItemAsync(int itemId, Region region, string locale)
+        public async Task<RequestResult<Item>> GetItemAsync(int itemId, Region region, Locale locale)
         {
             string host = GetHost(region);
             return await Get<Item>($"{host}/wow/item/{itemId}?locale={locale}&apikey={_apiKey}");
@@ -537,7 +544,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     A list of all item classes.
         /// </returns>
-        public async Task<RequestResult<IList<ItemClass>>> GetItemClassesAsync(Region region, string locale)
+        public async Task<RequestResult<IList<ItemClass>>> GetItemClassesAsync(Region region, Locale locale)
         {
             string host = GetHost(region);
             RequestResult<IList<ItemClass>> itemClassesList = await Get<IList<ItemClass>>($"{host}/wow/data/item/classes?locale={locale}&apikey={_apiKey}", "classes");
@@ -565,7 +572,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The specified item set.
         /// </returns>
-        public async Task<RequestResult<ItemSet>> GetItemSetAsync(int itemSetId, Region region, string locale)
+        public async Task<RequestResult<ItemSet>> GetItemSetAsync(int itemSetId, Region region, Locale locale)
         {
             string host = GetHost(region);
             return await Get<ItemSet>($"{host}/wow/item/set/{itemSetId}?locale={locale}&apikey={_apiKey}");
@@ -590,7 +597,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     A list of all supported mounts.
         /// </returns>
-        public async Task<RequestResult<IList<Mount>>> GetMountsAsync(Region region, string locale)
+        public async Task<RequestResult<IList<Mount>>> GetMountsAsync(Region region, Locale locale)
         {
             string host = GetHost(region);
             RequestResult<IList<Mount>> mountList = await Get<IList<Mount>>($"{host}/wow/mount/?locale={locale}&apikey={_apiKey}", "mounts");
@@ -616,7 +623,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     A list of all supported pets.
         /// </returns>
-        public async Task<RequestResult<IList<Pet>>> GetPetsAsync(Region region, string locale)
+        public async Task<RequestResult<IList<Pet>>> GetPetsAsync(Region region, Locale locale)
         {
             string host = GetHost(region);
             RequestResult<IList<Pet>> petList = await Get<IList<Pet>>($"{host}/wow/pet/?locale={locale}&apikey={_apiKey}", "pets");
@@ -644,7 +651,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The specified pet ability.
         /// </returns>
-        public async Task<RequestResult<PetAbility>> GetPetAbilityAsync(int abilityId, Region region, string locale)
+        public async Task<RequestResult<PetAbility>> GetPetAbilityAsync(int abilityId, Region region, Locale locale)
         {
             string host = GetHost(region);
             return await Get<PetAbility>($"{host}/wow/pet/ability/{abilityId}?locale={locale}&apikey={_apiKey}");
@@ -671,7 +678,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The specified pet species.
         /// </returns>
-        public async Task<RequestResult<PetSpecies>> GetPetSpeciesAsync(int speciesId, Region region, string locale)
+        public async Task<RequestResult<PetSpecies>> GetPetSpeciesAsync(int speciesId, Region region, Locale locale)
         {
             string host = GetHost(region);
             return await Get<PetSpecies>($"{host}/wow/pet/species/{speciesId}?locale={locale}&apikey={_apiKey}");
@@ -704,7 +711,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The pet stats for the specified pet species, level, breed, and quality.
         /// </returns>
-        public async Task<RequestResult<PetStats>> GetPetStatsAsync(int speciesId, int level, int breedId, BattlePetQuality quality, Region region, string locale)
+        public async Task<RequestResult<PetStats>> GetPetStatsAsync(int speciesId, int level, int breedId, BattlePetQuality quality, Region region, Locale locale)
         {
             string host = GetHost(region);
             return await Get<PetStats>($"{host}/wow/pet/stats/{speciesId}?level={level}&breedId={breedId}&qualityId={quality:D}&locale={locale}&apikey={_apiKey}");
@@ -729,7 +736,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     A list of all pet types.
         /// </returns>
-        public async Task<RequestResult<IList<PetType>>> GetPetTypesAsync(Region region, string locale)
+        public async Task<RequestResult<IList<PetType>>> GetPetTypesAsync(Region region, Locale locale)
         {
             string host = GetHost(region);
             RequestResult<IList<PetType>> petTypeList = await Get<IList<PetType>>($"{host}/wow/data/pet/types?locale={locale}&apikey={_apiKey}", "petTypes");
@@ -757,7 +764,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The PvP leaderboard for the specified bracket.
         /// </returns>
-        public async Task<RequestResult<PvpLeaderboard>> GetPvpLeaderboardAsync(string bracket, Region region, string locale)
+        public async Task<RequestResult<PvpLeaderboard>> GetPvpLeaderboardAsync(string bracket, Region region, Locale locale)
         {
             string host = GetHost(region);
             return await Get<PvpLeaderboard>($"{host}/wow/leaderboard/{bracket}?locale={locale}&apikey={_apiKey}");
@@ -784,7 +791,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The specified quest.
         /// </returns>
-        public async Task<RequestResult<Quest>> GetQuestAsync(int questId, Region region, string locale)
+        public async Task<RequestResult<Quest>> GetQuestAsync(int questId, Region region, Locale locale)
         {
             string host = GetHost(region);
             return await Get<Quest>($"{host}/wow/quest/{questId}?locale={locale}&apikey={_apiKey}");
@@ -809,7 +816,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The statuses for all realms.
         /// </returns>
-        public async Task<RequestResult<IList<Realm>>> GetRealmStatusAsync(Region region, string locale)
+        public async Task<RequestResult<IList<Realm>>> GetRealmStatusAsync(Region region, Locale locale)
         {
             string host = GetHost(region);
             RequestResult<IList<Realm>> realmList = await Get<IList<Realm>>($"{host}/wow/realm/status?locale={locale}&apikey={_apiKey}", "realms");
@@ -837,7 +844,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The specified recipe.
         /// </returns>
-        public async Task<RequestResult<Recipe>> GetRecipeAsync(int recipeId, Region region, string locale)
+        public async Task<RequestResult<Recipe>> GetRecipeAsync(int recipeId, Region region, Locale locale)
         {
             string host = GetHost(region);
             return await Get<Recipe>($"{host}/wow/recipe/{recipeId}?locale={locale}&apikey={_apiKey}");
@@ -864,7 +871,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The specified spell.
         /// </returns>
-        public async Task<RequestResult<Spell>> GetSpellAsync(int spellId, Region region, string locale)
+        public async Task<RequestResult<Spell>> GetSpellAsync(int spellId, Region region, Locale locale)
         {
             string host = GetHost(region);
             return await Get<Spell>($"{host}/wow/spell/{spellId}?locale={locale}&apikey={_apiKey}");
@@ -889,7 +896,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     A dictionary of talents, indexed by character class.
         /// </returns>
-        public async Task<RequestResult<IDictionary<CharacterClass, TalentSet>>> GetTalentsAsync(Region region, string locale)
+        public async Task<RequestResult<IDictionary<CharacterClass, TalentSet>>> GetTalentsAsync(Region region, Locale locale)
         {
             string host = GetHost(region);
             RequestResult<IDictionary<CharacterClass, TalentSet>> talents = await Get<IDictionary<CharacterClass, TalentSet>>($"{host}/wow/data/talents?locale={locale}&apikey={_apiKey}");
@@ -917,7 +924,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The specified zone.
         /// </returns>
-        public async Task<RequestResult<Zone>> GetZoneAsync(int zoneId, Region region, string locale)
+        public async Task<RequestResult<Zone>> GetZoneAsync(int zoneId, Region region, Locale locale)
         {
             string host = GetHost(region);
             return await Get<Zone>($"{host}/wow/zone/{zoneId}?locale={locale}&apikey={_apiKey}");
@@ -942,7 +949,7 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     A list of all supported zones.
         /// </returns>
-        public async Task<RequestResult<IList<Zone>>> GetZonesAsync(Region region, string locale)
+        public async Task<RequestResult<IList<Zone>>> GetZonesAsync(Region region, Locale locale)
         {
             string host = GetHost(region);
             RequestResult<IList<Zone>> zoneList = await Get<IList<Zone>>($"{host}/wow/zone/?locale={locale}&apikey={_apiKey}", "zones");
@@ -1032,6 +1039,22 @@ namespace ArgentPonyWarcraftClient
                 default:
                     return "https://us.api.battle.net";
             }
+        }
+
+        /// <summary>
+        ///     Checks if the locale is supported by the selected region.
+        /// </summary>
+        /// <param name="locale">The selected locale.</param>
+        /// <param name="region">The selected region.</param>
+        /// <returns>Returns true if the locale is supported by the selected region.</returns>
+        private static bool ValidateRegionLocale(Locale locale, Region region)
+        {
+            Type type = locale.GetType();
+            TypeInfo typeInfo = type.GetTypeInfo();
+            MemberInfo[] memberInfo = typeInfo.GetMember(locale.ToString());
+            LocaleRegion attribute = memberInfo[0].GetCustomAttribute<LocaleRegion>();
+
+            return attribute.Region == region;
         }
     }
 }


### PR DESCRIPTION
This is a breaking change but provides some safety for the end user. The locale is no longer a string, the end user can now see a list of possible locales via an Enum. An exception may be thrown if the locale selected is not supported by the selected region.

As I said this is a breaking change. Locales are no longer strings and the .NET Standard version has been changed to 1.5 to use additional reflection methods.
