### PR TITLE
Migration to updated API endpoints with OAuth client credentials flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Argent Pony Warcraft Client
-The Argent Pony Warcraft Client is a .NET client for the [Blizzard World of Warcraft Community Web APIs](https://dev.battle.net/).  It lets .NET applications easily access information about World of Warcraft characters, guilds, items, spells, and more.  It is a [.NET Standard](https://docs.microsoft.com/en-us/dotnet/standard/net-standard) 1.1 library, which means it supports a broad range of platforms, including .NET Core 1.0+ and .NET Framework 4.5+.
+The Argent Pony Warcraft Client is a .NET client for the [Blizzard World of Warcraft Community APIs](https://develop.battle.net/).  It lets .NET applications easily access information about World of Warcraft characters, guilds, items, spells, and more.  It is a [.NET Standard](https://docs.microsoft.com/en-us/dotnet/standard/net-standard) 1.1 library, which means it supports a broad range of platforms, including .NET Core 1.0+ and .NET Framework 4.5+.
 
 [![NuGet version](https://badge.fury.io/nu/ArgentPonyWarcraftClient.svg)](https://badge.fury.io/nu/ArgentPonyWarcraftClient)
 [![Build status](https://ci.appveyor.com/api/projects/status/9awhigq8te5uwllj?svg=true)](https://ci.appveyor.com/project/danjagnow/argentponywarcraftclient)
 
 ## Prerequisites
 
-All users of the Blizzard World of Warcraft Community Web APIs must have an API key.  Follow Blizzard's instructions to [register a new Mashery ID](https://dev.battle.net/member/register).
+All users of the Blizzard World of Warcraft Community Web APIs must have a Battle.net account and a client ID.  Follow Blizzard's [Getting Started](https://develop.battle.net/documentation/guides/getting-started) instructions.
 
 ## Installing via NuGet
 
@@ -24,17 +24,18 @@ Assuming you're working in C#, add the appropriate `using` statement to referenc
 using ArgentPonyWarcraftClient;
 ```
 
-Instantiate a `WarcraftClient` with the the API key that you registered for in the **Prerequisites** step.  For simplicity, the key is stored in the source code in the example below.  You should instead use the configuration API for your .NET platform to store the key securely.  For example, ASP.NET Core developers should read [Configuration in ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration).
+Instantiate a `WarcraftClient` with the the client ID and client secret that you registered for in the **Prerequisites** step.  For simplicity, these values are stored in the source code in the example below.  You should instead use the configuration API for your .NET platform to store the key securely.  For example, ASP.NET Core developers should read [Configuration in ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration).
 
 ``` cs
-string apiKey = "MY-API-KEY-GOES-HERE";
-var warcraftClient = new WarcraftClient(apiKey);
+string clientId = "MY-CLIENT-ID-GOES-HERE";
+string clientSecret = "MY-CLIENT-SECRET-GOES-HERE";
+var warcraftClient = new WarcraftClient(clientId, clientSecret);
 ```
 
 You can optionally specify the region and locale to use when calling the `WarcraftClient` constructor.  If you omit these parameters, it will default to `Region.US` and `"Locale.en_US"`.  Each method on `WarcraftClient` also has an overload that allows you to override these default values for the current call.
 
 ``` cs
-var warcraftClient = new WarcraftClient(apiKey, Region.US, "Locale.en_US");
+var warcraftClient = new WarcraftClient(clientId, clientSecret, Region.US, "Locale.en_US");
 ```
 
 Once you have your `WarcraftClient` instance, you can start asking for data.  All methods are asynchronous.  Here's an example for retrieving a character:
@@ -77,4 +78,4 @@ else
 }
 ```
 
-Take a look at the [WarcraftClientTests](https://github.com/danjagnow/ArgentPonyWarcraftClient/blob/master/src/ArgentPonyWarcraftClient.Tests/WarcraftClientTests.cs) class and the Blizzard World of Warcraft Community Web APIs documentation to learn more about what else you can do.
+Take a look at the [WarcraftClientTests](https://github.com/danjagnow/ArgentPonyWarcraftClient/blob/master/src/ArgentPonyWarcraftClient.Tests/WarcraftClientTests.cs) class and the Blizzard World of Warcraft Community APIs documentation to learn more about what else you can do.

--- a/src/ArgentPonyWarcraftClient.Tests/WarcraftClientTests.cs
+++ b/src/ArgentPonyWarcraftClient.Tests/WarcraftClientTests.cs
@@ -27,6 +27,12 @@ namespace ArgentPonyWarcraftClient.Tests
             var mockHttp = new MockHttpMessageHandler();
 
             mockHttp
+                .When("https://us.battle.net/oauth/token")
+                .Respond(
+                    mediaType: "application/json",
+                    content: @"{""access_token"": ""ACCESS-TOKEN"", ""token_type"": ""bearer"", ""expires_in"": 86399, ""scope"": ""example.scope""}");
+
+            mockHttp
                 .When("https://us.api.blizzard.com/wow/auction/data/Norgannon?locale=en_US")
                 .Respond(mediaType: "application/json", content: Resources.AuctionResponse);
 
@@ -459,6 +465,12 @@ namespace ArgentPonyWarcraftClient.Tests
             var mockHttp = new MockHttpMessageHandler();
 
             mockHttp
+                .When("https://us.battle.net/oauth/token")
+                .Respond(
+                    mediaType: "application/json",
+                    content: @"{""access_token"": ""ACCESS-TOKEN"", ""token_type"": ""bearer"", ""expires_in"": 86399, ""scope"": ""example.scope""}");
+
+            mockHttp
                 .When(requestUri)
                 .Respond(mediaType: "application/json", content: responseContent);
 
@@ -473,6 +485,12 @@ namespace ArgentPonyWarcraftClient.Tests
         private static IWarcraftClient BuildMockClient(string requestUri, string responseContent, HttpStatusCode statusCode)
         {
             var mockHttp = new MockHttpMessageHandler();
+
+            mockHttp
+                .When("https://us.battle.net/oauth/token")
+                .Respond(
+                    mediaType: "application/json",
+                    content: @"{""access_token"": ""ACCESS-TOKEN"", ""token_type"": ""bearer"", ""expires_in"": 86399, ""scope"": ""example.scope""}");
 
             mockHttp
                 .When(requestUri)

--- a/src/ArgentPonyWarcraftClient.Tests/WarcraftClientTests.cs
+++ b/src/ArgentPonyWarcraftClient.Tests/WarcraftClientTests.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetAchievementAsync_Gets_Achievement()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.battle.net/wow/achievement/2144?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/achievement/2144?locale=en_US&apikey=keyhere",
                 responseContent: Resources.AchievementResponse);
 
             RequestResult<Achievement> result = await warcraftClient.GetAchievementAsync(2144);
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient.Tests
             var mockHttp = new MockHttpMessageHandler();
 
             mockHttp
-                .When("https://us.api.battle.net/wow/auction/data/Norgannon?locale=en_US&apikey=keyhere")
+                .When("https://us.api.blizzard.com/wow/auction/data/Norgannon?locale=en_US&apikey=keyhere")
                 .Respond(mediaType: "application/json", content: Resources.AuctionResponse);
 
             mockHttp
@@ -51,7 +51,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetBattlegroupAsync_Gets_Battlegroups()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.battle.net/wow/data/battlegroups/?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/data/battlegroups/?locale=en_US&apikey=keyhere",
                 responseContent: Resources.BattlegroupsResponse);
 
             RequestResult<IList<Battlegroup>> result = await warcraftClient.GetBattlegroupsAsync();
@@ -63,7 +63,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetBossAsync_Gets_Boss()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.battle.net/wow/boss/24723?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/boss/24723?locale=en_US&apikey=keyhere",
                 responseContent: Resources.BossResponse);
 
             RequestResult<Boss> result = await warcraftClient.GetBossAsync(24723);
@@ -74,7 +74,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetBossesAsync_Gets_Bosses()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.battle.net/wow/boss/?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/boss/?locale=en_US&apikey=keyhere",
                 responseContent: Resources.BossesResponse);
 
             RequestResult<IList<Boss>> result = await warcraftClient.GetBossesAsync();
@@ -86,7 +86,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetChallengesAsync_Gets_Challenges_For_Region()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.battle.net/wow/challenge/region?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/challenge/region?locale=en_US&apikey=keyhere",
                 responseContent: Resources.ChallengesForRegionResponse);
 
             RequestResult<IList<Challenge>> result = await warcraftClient.GetChallengesAsync();
@@ -97,7 +97,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetChallengesAsync_Gets_Challenges()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.battle.net/wow/challenge/Norgannon?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/challenge/Norgannon?locale=en_US&apikey=keyhere",
                 responseContent: Resources.ChallengesResponse);
 
             RequestResult<IList<Challenge>> result = await warcraftClient.GetChallengesAsync("Norgannon");
@@ -108,7 +108,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetCharacterAsync_Gets_Character()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.battle.net/wow/character/Norgannon/Thorpe?&locale=en_US&fields=achievements,appearance,feed,guild,hunter pets,items,mounts,pets,pet slots,professions,progression,pvp,quests,reputation,statistics,stats,talents,titles,audit&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/character/Norgannon/Thorpe?&locale=en_US&fields=achievements,appearance,feed,guild,hunter pets,items,mounts,pets,pet slots,professions,progression,pvp,quests,reputation,statistics,stats,talents,titles,audit&apikey=keyhere",
                 responseContent: Resources.CharacterResponse);
 
             RequestResult<Character> result = await warcraftClient.GetCharacterAsync("Norgannon", "Thorpe", CharacterFields.All);
@@ -119,7 +119,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetCharacterClassesAsync_Gets_Character_Classes()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.battle.net/wow/data/character/classes?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/data/character/classes?locale=en_US&apikey=keyhere",
                 responseContent: Resources.CharacterClassesResponse);
 
             RequestResult<IList<CharacterClassData>> result = await warcraftClient.GetCharacterClassesAsync();
@@ -131,7 +131,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetCharacterAchievementsAsync_Gets_Achievements()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.battle.net/wow/data/character/achievements?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/data/character/achievements?locale=en_US&apikey=keyhere",
                 responseContent: Resources.CharacterAchievementsResponse);
 
             RequestResult<IList<AchievementCategory>> result = await warcraftClient.GetCharacterAchievementsAsync();
@@ -143,7 +143,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetCharacterRacesAsync_Gets_Character_Races()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.battle.net/wow/data/character/races?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/data/character/races?locale=en_US&apikey=keyhere",
                 responseContent: Resources.CharacterRacesResponse);
 
             RequestResult<IList<CharacterRace>> result = await warcraftClient.GetCharacterRacesAsync();
@@ -155,7 +155,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetCharactersAsync_Gets_Characters()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.battle.net/wow/user/characters?access_token=tokenhere",
+                requestUri: "https://us.api.blizzard.com/wow/user/characters?access_token=tokenhere",
                 responseContent: Resources.CharactersResponse);
 
             RequestResult<IList<GuildCharacter>> result = await warcraftClient.GetCharactersAsync("tokenhere");
@@ -167,7 +167,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetGuildAsync_Gets_Guild()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.battle.net/wow/guild/Norgannon/Mythical%20Warriors?locale=en_US&fields=challenge&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/guild/Norgannon/Mythical%20Warriors?locale=en_US&fields=challenge&apikey=keyhere",
                 responseContent: Resources.GuildResponse);
 
             RequestResult<Guild> result = await warcraftClient.GetGuildAsync("Norgannon", "Mythical Warriors", GuildFields.Challenge);
@@ -178,7 +178,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetGuildAchievementsAsync_Gets_Guild_Achievements()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.battle.net/wow/data/guild/achievements?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/data/guild/achievements?locale=en_US&apikey=keyhere",
                 responseContent: Resources.GuildAchievementsResponse);
 
             RequestResult<IList<AchievementCategory>> result = await warcraftClient.GetGuildAchievementsAsync();
@@ -190,7 +190,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetGuildPerksAsync_Gets_Guild_Perks()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.battle.net/wow/data/guild/perks?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/data/guild/perks?locale=en_US&apikey=keyhere",
                 responseContent: Resources.GuildPerksResponse);
 
             RequestResult<IList<Perk>> result = await warcraftClient.GetGuildPerksAsync();
@@ -202,7 +202,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetGuildRewardsAsync_Gets_Guild_Rewards()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.battle.net/wow/data/guild/rewards?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/data/guild/rewards?locale=en_US&apikey=keyhere",
                 responseContent: Resources.GuildRewardsResponse);
 
             RequestResult<IList<Reward>> result = await warcraftClient.GetGuildRewardsAsync();
@@ -214,7 +214,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetItemAsync_Gets_Item()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.battle.net/wow/item/18803?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/item/18803?locale=en_US&apikey=keyhere",
                 responseContent: Resources.ItemResponse);
 
             RequestResult<Item> result = await warcraftClient.GetItemAsync(18803);
@@ -225,7 +225,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetItemClassesAsync_Gets_Item_Classes()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.battle.net/wow/data/item/classes?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/data/item/classes?locale=en_US&apikey=keyhere",
                 responseContent: Resources.ItemClassesResponse);
 
             RequestResult<IList<ItemClass>> result = await warcraftClient.GetItemClassesAsync();
@@ -237,7 +237,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetItemSetAsync_Gets_Item_Set()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.battle.net/wow/item/set/1060?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/item/set/1060?locale=en_US&apikey=keyhere",
                 responseContent: Resources.ItemSetResponse);
 
             RequestResult<ItemSet> result = await warcraftClient.GetItemSetAsync(1060);
@@ -248,7 +248,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetMountsAsync_Gets_Mounts()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.battle.net/wow/mount/?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/mount/?locale=en_US&apikey=keyhere",
                 responseContent: Resources.MountsResponse);
 
             RequestResult<IList<Mount>> result = await warcraftClient.GetMountsAsync();
@@ -260,7 +260,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetPetsAsync_Gets_Pets()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.battle.net/wow/pet/?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/pet/?locale=en_US&apikey=keyhere",
                 responseContent: Resources.PetsResponse);
 
             RequestResult<IList<Pet>> result = await warcraftClient.GetPetsAsync();
@@ -272,7 +272,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetPetAbilityAsync_Gets_Pet_Ability()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.battle.net/wow/pet/ability/640?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/pet/ability/640?locale=en_US&apikey=keyhere",
                 responseContent: Resources.PetAbilityResponse);
 
             RequestResult<PetAbility> result = await warcraftClient.GetPetAbilityAsync(640);
@@ -283,7 +283,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetPetSpeciesAsync_Gets_Pet_Species()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.battle.net/wow/pet/species/258?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/pet/species/258?locale=en_US&apikey=keyhere",
                 responseContent: Resources.PetSpeciesResponse);
 
             RequestResult<PetSpecies> result = await warcraftClient.GetPetSpeciesAsync(258);
@@ -294,7 +294,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetPetStatsAsync_Gets_Pet_Stats()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.battle.net/wow/pet/stats/258?level=25&breedId=5&qualityId=4&locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/pet/stats/258?level=25&breedId=5&qualityId=4&locale=en_US&apikey=keyhere",
                 responseContent: Resources.PetStatsResponse);
 
             RequestResult<PetStats> result = await warcraftClient.GetPetStatsAsync(258, 25, 5, BattlePetQuality.Epic);
@@ -305,7 +305,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetPetTypesAsync_Gets_Pet_Types()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.battle.net/wow/data/pet/types?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/data/pet/types?locale=en_US&apikey=keyhere",
                 responseContent: Resources.PetTypesResponse);
 
             RequestResult<IList<PetType>> result = await warcraftClient.GetPetTypesAsync();
@@ -317,7 +317,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetPvpLeaderboardAsync_Gets_Leaderboard()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.battle.net/wow/leaderboard/2v2?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/leaderboard/2v2?locale=en_US&apikey=keyhere",
                 responseContent: Resources.PvpLeaderboardResponse);
 
             RequestResult<PvpLeaderboard> result = await warcraftClient.GetPvpLeaderboardAsync("2v2");
@@ -328,7 +328,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetQuestAsync_Gets_Quest()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.battle.net/wow/quest/13146?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/quest/13146?locale=en_US&apikey=keyhere",
                 responseContent: Resources.QuestResponse);
 
             RequestResult<Quest> result = await warcraftClient.GetQuestAsync(13146);
@@ -339,7 +339,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetRealmsAsync_Gets_Realms()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.battle.net/wow/realm/status?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/realm/status?locale=en_US&apikey=keyhere",
                 responseContent: Resources.RealmsResponse);
 
             RequestResult<IList<Realm>> result = await warcraftClient.GetRealmStatusAsync();
@@ -351,7 +351,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetRecipe_Gets_Recipe()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.battle.net/wow/recipe/33994?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/recipe/33994?locale=en_US&apikey=keyhere",
                 responseContent: Resources.RecipeResponse);
 
             RequestResult<Recipe> result = await warcraftClient.GetRecipeAsync(33994);
@@ -362,7 +362,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetSpellAsync_Gets_Spell()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.battle.net/wow/spell/79733?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/spell/79733?locale=en_US&apikey=keyhere",
                 responseContent: Resources.SpellResponse);
 
             RequestResult<Spell> result = await warcraftClient.GetSpellAsync(79733);
@@ -373,7 +373,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetTalentsAsync_Gets_Talents()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.battle.net/wow/data/talents?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/data/talents?locale=en_US&apikey=keyhere",
                 responseContent: Resources.TalentsResponse);
 
             RequestResult<IDictionary<CharacterClass, TalentSet>> result = await warcraftClient.GetTalentsAsync();
@@ -385,7 +385,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetUserAsync_Gets_User()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.battle.net/account/user?access_token=tokenhere",
+                requestUri: "https://us.api.blizzard.com/account/user?access_token=tokenhere",
                 responseContent: Resources.UserResponse);
 
             RequestResult<UserAccount> result = await warcraftClient.GetUserAsync("tokenhere");
@@ -396,7 +396,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetZoneAsync_Gets_Zone()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.battle.net/wow/zone/4131?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/zone/4131?locale=en_US&apikey=keyhere",
                 responseContent: Resources.ZoneResponse);
 
             RequestResult<Zone> result = await warcraftClient.GetZoneAsync(4131);
@@ -407,7 +407,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetZonesAsync_Gets_Zones()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.battle.net/wow/zone/?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/zone/?locale=en_US&apikey=keyhere",
                 responseContent: Resources.ZonesResponse);
 
             RequestResult<IList<Zone>> result = await warcraftClient.GetZonesAsync();
@@ -418,7 +418,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void ProducesNotFoundError()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.battle.net/wow/zone/99999991?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/zone/99999991?locale=en_US&apikey=keyhere",
                 responseContent: Resources.Zone404ErrorResponse,
                 statusCode: HttpStatusCode.NotFound);
 
@@ -433,7 +433,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void ProducesForbiddenError()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.battle.net/wow/zone/4131?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/zone/4131?locale=en_US&apikey=keyhere",
                 responseContent: Resources.AccountInactive403ForbiddenResponse,
                 statusCode: HttpStatusCode.Forbidden);
 

--- a/src/ArgentPonyWarcraftClient.Tests/WarcraftClientTests.cs
+++ b/src/ArgentPonyWarcraftClient.Tests/WarcraftClientTests.cs
@@ -14,7 +14,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetAchievementAsync_Gets_Achievement()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.blizzard.com/wow/achievement/2144?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/achievement/2144?locale=en_US",
                 responseContent: Resources.AchievementResponse);
 
             RequestResult<Achievement> result = await warcraftClient.GetAchievementAsync(2144);
@@ -27,7 +27,7 @@ namespace ArgentPonyWarcraftClient.Tests
             var mockHttp = new MockHttpMessageHandler();
 
             mockHttp
-                .When("https://us.api.blizzard.com/wow/auction/data/Norgannon?locale=en_US&apikey=keyhere")
+                .When("https://us.api.blizzard.com/wow/auction/data/Norgannon?locale=en_US")
                 .Respond(mediaType: "application/json", content: Resources.AuctionResponse);
 
             mockHttp
@@ -35,7 +35,8 @@ namespace ArgentPonyWarcraftClient.Tests
                 .Respond(mediaType: "application/json", content: Resources.AuctionDataFileResponse);
 
             IWarcraftClient warcraftClient = new WarcraftClient(
-                apiKey: "keyhere",
+                clientId: "clientIdHere",
+                clientSecret: "clientSecretHere",
                 region: Region.US,
                 locale: Locale.en_US,
                 client: mockHttp.ToHttpClient());
@@ -51,7 +52,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetBattlegroupAsync_Gets_Battlegroups()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.blizzard.com/wow/data/battlegroups/?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/data/battlegroups/?locale=en_US",
                 responseContent: Resources.BattlegroupsResponse);
 
             RequestResult<IList<Battlegroup>> result = await warcraftClient.GetBattlegroupsAsync();
@@ -63,7 +64,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetBossAsync_Gets_Boss()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.blizzard.com/wow/boss/24723?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/boss/24723?locale=en_US",
                 responseContent: Resources.BossResponse);
 
             RequestResult<Boss> result = await warcraftClient.GetBossAsync(24723);
@@ -74,7 +75,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetBossesAsync_Gets_Bosses()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.blizzard.com/wow/boss/?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/boss/?locale=en_US",
                 responseContent: Resources.BossesResponse);
 
             RequestResult<IList<Boss>> result = await warcraftClient.GetBossesAsync();
@@ -86,7 +87,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetChallengesAsync_Gets_Challenges_For_Region()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.blizzard.com/wow/challenge/region?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/challenge/region?locale=en_US",
                 responseContent: Resources.ChallengesForRegionResponse);
 
             RequestResult<IList<Challenge>> result = await warcraftClient.GetChallengesAsync();
@@ -97,7 +98,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetChallengesAsync_Gets_Challenges()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.blizzard.com/wow/challenge/Norgannon?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/challenge/Norgannon?locale=en_US",
                 responseContent: Resources.ChallengesResponse);
 
             RequestResult<IList<Challenge>> result = await warcraftClient.GetChallengesAsync("Norgannon");
@@ -108,7 +109,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetCharacterAsync_Gets_Character()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.blizzard.com/wow/character/Norgannon/Thorpe?&locale=en_US&fields=achievements,appearance,feed,guild,hunter pets,items,mounts,pets,pet slots,professions,progression,pvp,quests,reputation,statistics,stats,talents,titles,audit&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/character/Norgannon/Thorpe?&locale=en_US&fields=achievements,appearance,feed,guild,hunter pets,items,mounts,pets,pet slots,professions,progression,pvp,quests,reputation,statistics,stats,talents,titles,audit",
                 responseContent: Resources.CharacterResponse);
 
             RequestResult<Character> result = await warcraftClient.GetCharacterAsync("Norgannon", "Thorpe", CharacterFields.All);
@@ -119,7 +120,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetCharacterClassesAsync_Gets_Character_Classes()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.blizzard.com/wow/data/character/classes?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/data/character/classes?locale=en_US",
                 responseContent: Resources.CharacterClassesResponse);
 
             RequestResult<IList<CharacterClassData>> result = await warcraftClient.GetCharacterClassesAsync();
@@ -131,7 +132,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetCharacterAchievementsAsync_Gets_Achievements()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.blizzard.com/wow/data/character/achievements?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/data/character/achievements?locale=en_US",
                 responseContent: Resources.CharacterAchievementsResponse);
 
             RequestResult<IList<AchievementCategory>> result = await warcraftClient.GetCharacterAchievementsAsync();
@@ -143,7 +144,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetCharacterRacesAsync_Gets_Character_Races()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.blizzard.com/wow/data/character/races?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/data/character/races?locale=en_US",
                 responseContent: Resources.CharacterRacesResponse);
 
             RequestResult<IList<CharacterRace>> result = await warcraftClient.GetCharacterRacesAsync();
@@ -167,7 +168,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetGuildAsync_Gets_Guild()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.blizzard.com/wow/guild/Norgannon/Mythical%20Warriors?locale=en_US&fields=challenge&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/guild/Norgannon/Mythical%20Warriors?locale=en_US&fields=challenge",
                 responseContent: Resources.GuildResponse);
 
             RequestResult<Guild> result = await warcraftClient.GetGuildAsync("Norgannon", "Mythical Warriors", GuildFields.Challenge);
@@ -178,7 +179,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetGuildAchievementsAsync_Gets_Guild_Achievements()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.blizzard.com/wow/data/guild/achievements?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/data/guild/achievements?locale=en_US",
                 responseContent: Resources.GuildAchievementsResponse);
 
             RequestResult<IList<AchievementCategory>> result = await warcraftClient.GetGuildAchievementsAsync();
@@ -190,7 +191,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetGuildPerksAsync_Gets_Guild_Perks()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.blizzard.com/wow/data/guild/perks?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/data/guild/perks?locale=en_US",
                 responseContent: Resources.GuildPerksResponse);
 
             RequestResult<IList<Perk>> result = await warcraftClient.GetGuildPerksAsync();
@@ -202,7 +203,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetGuildRewardsAsync_Gets_Guild_Rewards()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.blizzard.com/wow/data/guild/rewards?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/data/guild/rewards?locale=en_US",
                 responseContent: Resources.GuildRewardsResponse);
 
             RequestResult<IList<Reward>> result = await warcraftClient.GetGuildRewardsAsync();
@@ -214,7 +215,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetItemAsync_Gets_Item()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.blizzard.com/wow/item/18803?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/item/18803?locale=en_US",
                 responseContent: Resources.ItemResponse);
 
             RequestResult<Item> result = await warcraftClient.GetItemAsync(18803);
@@ -225,7 +226,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetItemClassesAsync_Gets_Item_Classes()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.blizzard.com/wow/data/item/classes?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/data/item/classes?locale=en_US",
                 responseContent: Resources.ItemClassesResponse);
 
             RequestResult<IList<ItemClass>> result = await warcraftClient.GetItemClassesAsync();
@@ -237,7 +238,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetItemSetAsync_Gets_Item_Set()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.blizzard.com/wow/item/set/1060?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/item/set/1060?locale=en_US",
                 responseContent: Resources.ItemSetResponse);
 
             RequestResult<ItemSet> result = await warcraftClient.GetItemSetAsync(1060);
@@ -248,7 +249,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetMountsAsync_Gets_Mounts()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.blizzard.com/wow/mount/?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/mount/?locale=en_US",
                 responseContent: Resources.MountsResponse);
 
             RequestResult<IList<Mount>> result = await warcraftClient.GetMountsAsync();
@@ -260,7 +261,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetPetsAsync_Gets_Pets()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.blizzard.com/wow/pet/?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/pet/?locale=en_US",
                 responseContent: Resources.PetsResponse);
 
             RequestResult<IList<Pet>> result = await warcraftClient.GetPetsAsync();
@@ -272,7 +273,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetPetAbilityAsync_Gets_Pet_Ability()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.blizzard.com/wow/pet/ability/640?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/pet/ability/640?locale=en_US",
                 responseContent: Resources.PetAbilityResponse);
 
             RequestResult<PetAbility> result = await warcraftClient.GetPetAbilityAsync(640);
@@ -283,7 +284,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetPetSpeciesAsync_Gets_Pet_Species()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.blizzard.com/wow/pet/species/258?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/pet/species/258?locale=en_US",
                 responseContent: Resources.PetSpeciesResponse);
 
             RequestResult<PetSpecies> result = await warcraftClient.GetPetSpeciesAsync(258);
@@ -294,7 +295,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetPetStatsAsync_Gets_Pet_Stats()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.blizzard.com/wow/pet/stats/258?level=25&breedId=5&qualityId=4&locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/pet/stats/258?level=25&breedId=5&qualityId=4&locale=en_US",
                 responseContent: Resources.PetStatsResponse);
 
             RequestResult<PetStats> result = await warcraftClient.GetPetStatsAsync(258, 25, 5, BattlePetQuality.Epic);
@@ -305,7 +306,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetPetTypesAsync_Gets_Pet_Types()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.blizzard.com/wow/data/pet/types?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/data/pet/types?locale=en_US",
                 responseContent: Resources.PetTypesResponse);
 
             RequestResult<IList<PetType>> result = await warcraftClient.GetPetTypesAsync();
@@ -317,7 +318,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetPvpLeaderboardAsync_Gets_Leaderboard()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.blizzard.com/wow/leaderboard/2v2?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/leaderboard/2v2?locale=en_US",
                 responseContent: Resources.PvpLeaderboardResponse);
 
             RequestResult<PvpLeaderboard> result = await warcraftClient.GetPvpLeaderboardAsync("2v2");
@@ -328,7 +329,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetQuestAsync_Gets_Quest()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.blizzard.com/wow/quest/13146?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/quest/13146?locale=en_US",
                 responseContent: Resources.QuestResponse);
 
             RequestResult<Quest> result = await warcraftClient.GetQuestAsync(13146);
@@ -339,7 +340,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetRealmsAsync_Gets_Realms()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.blizzard.com/wow/realm/status?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/realm/status?locale=en_US",
                 responseContent: Resources.RealmsResponse);
 
             RequestResult<IList<Realm>> result = await warcraftClient.GetRealmStatusAsync();
@@ -351,7 +352,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetRecipe_Gets_Recipe()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.blizzard.com/wow/recipe/33994?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/recipe/33994?locale=en_US",
                 responseContent: Resources.RecipeResponse);
 
             RequestResult<Recipe> result = await warcraftClient.GetRecipeAsync(33994);
@@ -362,7 +363,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetSpellAsync_Gets_Spell()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.blizzard.com/wow/spell/79733?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/spell/79733?locale=en_US",
                 responseContent: Resources.SpellResponse);
 
             RequestResult<Spell> result = await warcraftClient.GetSpellAsync(79733);
@@ -373,7 +374,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetTalentsAsync_Gets_Talents()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.blizzard.com/wow/data/talents?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/data/talents?locale=en_US",
                 responseContent: Resources.TalentsResponse);
 
             RequestResult<IDictionary<CharacterClass, TalentSet>> result = await warcraftClient.GetTalentsAsync();
@@ -396,7 +397,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetZoneAsync_Gets_Zone()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.blizzard.com/wow/zone/4131?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/zone/4131?locale=en_US",
                 responseContent: Resources.ZoneResponse);
 
             RequestResult<Zone> result = await warcraftClient.GetZoneAsync(4131);
@@ -407,7 +408,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void GetZonesAsync_Gets_Zones()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.blizzard.com/wow/zone/?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/zone/?locale=en_US",
                 responseContent: Resources.ZonesResponse);
 
             RequestResult<IList<Zone>> result = await warcraftClient.GetZonesAsync();
@@ -418,7 +419,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void ProducesNotFoundError()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.blizzard.com/wow/zone/99999991?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/zone/99999991?locale=en_US",
                 responseContent: Resources.Zone404ErrorResponse,
                 statusCode: HttpStatusCode.NotFound);
 
@@ -433,7 +434,7 @@ namespace ArgentPonyWarcraftClient.Tests
         public async void ProducesForbiddenError()
         {
             IWarcraftClient warcraftClient = BuildMockClient(
-                requestUri: "https://us.api.blizzard.com/wow/zone/4131?locale=en_US&apikey=keyhere",
+                requestUri: "https://us.api.blizzard.com/wow/zone/4131?locale=en_US",
                 responseContent: Resources.AccountInactive403ForbiddenResponse,
                 statusCode: HttpStatusCode.Forbidden);
 
@@ -449,7 +450,7 @@ namespace ArgentPonyWarcraftClient.Tests
         {
             Assert.Throws<ArgumentException>(() =>
             {
-                IWarcraftClient client = new WarcraftClient("APIKEY", Region.Korea, Locale.fr_FR);
+                IWarcraftClient client = new WarcraftClient("clientIdHere", "clientSecretHere", Region.Korea, Locale.fr_FR);
             });
         }
 
@@ -462,7 +463,8 @@ namespace ArgentPonyWarcraftClient.Tests
                 .Respond(mediaType: "application/json", content: responseContent);
 
             return new WarcraftClient(
-                apiKey: "keyhere",
+                clientId: "clientIdHere",
+                clientSecret: "clientSecretHere",
                 region: Region.US,
                 locale: Locale.en_US,
                 client: mockHttp.ToHttpClient());
@@ -480,7 +482,8 @@ namespace ArgentPonyWarcraftClient.Tests
                     content: responseContent);
 
             return new WarcraftClient(
-                apiKey: "keyhere",
+                clientId: "clientIdHere",
+                clientSecret: "clientSecretHere",
                 region: Region.US,
                 locale: Locale.en_US,
                 client: mockHttp.ToHttpClient());

--- a/src/ArgentPonyWarcraftClient/Utilities/AccessToken.cs
+++ b/src/ArgentPonyWarcraftClient/Utilities/AccessToken.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+
+namespace ArgentPonyWarcraftClient
+{
+    /// <summary>
+    /// An OAuth access token for the Blizzard API.
+    /// </summary>
+    internal class OAuthAccessToken
+    {
+        [JsonProperty("access_token")]
+        public string AccessToken { get; set; }
+
+        [JsonProperty("token_type")]
+        public string TokenType { get; set; }
+
+        [JsonProperty("expires_in")]
+        public long ExpiresIn { get; set; }
+
+        [JsonProperty("scope")]
+        public string Scope { get; set; }
+    }
+}

--- a/src/ArgentPonyWarcraftClient/WarcraftClient.cs
+++ b/src/ArgentPonyWarcraftClient/WarcraftClient.cs
@@ -1082,16 +1082,16 @@ namespace ArgentPonyWarcraftClient
             switch (region)
             {
                 case Region.China:
-                    return "https://www.battlenet.com.cn";
+                    return "https://cn.api.blizzard.com";
                 case Region.Europe:
-                    return "https://eu.api.battle.net";
+                    return "https://eu.api.blizzard.com";
                 case Region.Korea:
-                    return "https://kr.api.battle.net";
+                    return "https://kr.api.blizzard.com";
                 case Region.Taiwan:
-                    return "https://tw.api.battle.net";
+                    return "https://tw.api.blizzard.com";
                 case Region.US:
                 default:
-                    return "https://us.api.battle.net";
+                    return "https://us.api.blizzard.com";
             }
         }
 

--- a/src/ArgentPonyWarcraftClient/WarcraftClient.cs
+++ b/src/ArgentPonyWarcraftClient/WarcraftClient.cs
@@ -1042,7 +1042,7 @@ namespace ArgentPonyWarcraftClient
             // Acquire a new OAuth token if we don't have one. Get a new one if it's expired.
             if (_token == null || DateTime.UtcNow >= _tokenExpiration)
             {
-                _token = await GetOAuthToken(Region.US).ConfigureAwait(false);
+                _token = await GetOAuthToken(region).ConfigureAwait(false);
                 _tokenExpiration = DateTime.UtcNow.AddSeconds(_token.ExpiresIn).AddSeconds(-30);
             }
 

--- a/src/ArgentPonyWarcraftClient/WarcraftClient.cs
+++ b/src/ArgentPonyWarcraftClient/WarcraftClient.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Reflection;
+using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -14,48 +16,56 @@ namespace ArgentPonyWarcraftClient
     public class WarcraftClient : IWarcraftClient
     {
         private readonly HttpClient _client;
-        private readonly string _apiKey;
+        private readonly string _clientId;
+        private readonly string _clientSecret;
         private readonly Region _region;
         private readonly Locale _locale;
+
+        private OAuthAccessToken _token;
+        private DateTime _tokenExpiration;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="WarcraftClient"/> class.
         /// </summary>
+        /// <param name="clientId">The Blizzard OAuth client ID.</param>
+        /// <param name="clientSecret">The Blizzard OAuth client secret.</param>
         /// <remarks>
         ///     Defaults the region to US and the locale to "en_US".
         /// </remarks>
-        /// <param name="apiKey">The API key.</param>
-        public WarcraftClient(string apiKey) : this(apiKey, Region.US, Locale.en_US)
+        public WarcraftClient(string clientId, string clientSecret) : this(clientId, clientSecret, Region.US, Locale.en_US)
         {
         }
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="WarcraftClient"/> class.
         /// </summary>
-        /// <param name="apiKey">Blizzard Mashery API key. To create an API key visit https://dev.battle.net/member/register </param>
+        /// <param name="clientId">The Blizzard OAuth client ID.</param>
+        /// <param name="clientSecret">The Blizzard OAuth client secret.</param>
         /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
         /// <param name="locale">
         ///     Specifies the language that the result will be in. Visit
         ///     https://dev.battle.net/docs/read/community_apis to see a list of available locales.
         /// </param>
-        public WarcraftClient(string apiKey, Region region, Locale locale) : this(apiKey, region, locale, InternalHttpClient.Instance)
+        public WarcraftClient(string clientId, string clientSecret, Region region, Locale locale) : this(clientId, clientSecret, region, locale, InternalHttpClient.Instance)
         {
         }
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="WarcraftClient"/> class.
         /// </summary>
-        /// <param name="apiKey">Blizzard Mashery API key. To create an API key visit https://dev.battle.net/member/register </param>
+        /// <param name="clientId">The Blizzard OAuth client ID.</param>
+        /// <param name="clientSecret">The Blizzard OAuth client secret.</param>
         /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
         /// <param name="locale">
         ///     Specifies the language that the result will be in. Visit
         ///     https://dev.battle.net/docs/read/community_apis to see a list of available locales.
         /// </param>
         /// <param name="client">The <see cref="HttpClient"/> that communicates with Blizzard.</param>
-        public WarcraftClient(string apiKey, Region region, Locale locale, HttpClient client)
+        public WarcraftClient(string clientId, string clientSecret, Region region, Locale locale, HttpClient client)
         {
             _client = client ?? throw new ArgumentNullException(nameof(client));
-            _apiKey = apiKey ?? throw new ArgumentNullException(nameof(apiKey));
+            _clientId = clientId ?? throw new ArgumentNullException(nameof(clientId));
+            _clientSecret = clientSecret ?? throw new ArgumentNullException(nameof(clientSecret));
 
             if (!ValidateRegionLocale(locale, region))
             {
@@ -90,7 +100,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<Achievement>> GetAchievementAsync(int id, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await Get<Achievement>($"{host}/wow/achievement/{id}?locale={locale}&apikey={_apiKey}");
+            return await Get<Achievement>(region, $"{host}/wow/achievement/{id}?locale={locale}");
         }
 
         /// <summary>
@@ -117,7 +127,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<AuctionFiles>> GetAuctionAsync(string realm, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await Get<AuctionFiles>($"{host}/wow/auction/data/{realm}?locale={locale}&apikey={_apiKey}");
+            return await Get<AuctionFiles>(region, $"{host}/wow/auction/data/{realm}?locale={locale}");
         }
 
         /// <summary>
@@ -129,7 +139,8 @@ namespace ArgentPonyWarcraftClient
         /// </returns>
         public async Task<RequestResult<AuctionHouseSnapshot>> GetAuctionHouseSnapshotAsync(string url)
         {
-            return await Get<AuctionHouseSnapshot>(url);
+            // TODO: Need to extract the region from the URL or add it to the method signature.
+            return await Get<AuctionHouseSnapshot>(Region.US, url);
         }
 
         /// <summary>
@@ -154,7 +165,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<IList<Battlegroup>>> GetBattlegroupsAsync(Region region, Locale locale)
         {
             string host = GetHost(region);
-            RequestResult<IList<Battlegroup>> battlegroupList = await Get<IList<Battlegroup>>($"{host}/wow/data/battlegroups/?locale={locale}&apikey={_apiKey}", "battlegroups");
+            RequestResult<IList<Battlegroup>> battlegroupList = await Get<IList<Battlegroup>>(region, $"{host}/wow/data/battlegroups/?locale={locale}", "battlegroups");
 
             return battlegroupList;
         }
@@ -189,7 +200,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<Boss>> GetBossAsync(int id, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await Get<Boss>($"{host}/wow/boss/{id}?locale={locale}&apikey={_apiKey}");
+            return await Get<Boss>(region, $"{host}/wow/boss/{id}?locale={locale}");
         }
 
         /// <summary>
@@ -220,7 +231,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<IList<Boss>>> GetBossesAsync(Region region, Locale locale)
         {
             string host = GetHost(region);
-            RequestResult<IList<Boss>> bossList = await Get<IList<Boss>>($"{host}/wow/boss/?locale={locale}&apikey={_apiKey}", "bosses");
+            RequestResult<IList<Boss>> bossList = await Get<IList<Boss>>(region, $"{host}/wow/boss/?locale={locale}", "bosses");
             return bossList;
         }
 
@@ -246,7 +257,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<IList<Challenge>>> GetChallengesAsync(Region region, Locale locale)
         {
             string host = GetHost(region);
-            RequestResult<IList<Challenge>> challengeList = await Get<IList<Challenge>>($"{host}/wow/challenge/region?locale={locale}&apikey={_apiKey}", "challenge");
+            RequestResult<IList<Challenge>> challengeList = await Get<IList<Challenge>>(region, $"{host}/wow/challenge/region?locale={locale}", "challenge");
             return challengeList;
         }
 
@@ -274,7 +285,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<IList<Challenge>>> GetChallengesAsync(string realm, Region region, Locale locale)
         {
             string host = GetHost(region);
-            RequestResult<IList<Challenge>> challengeList = await Get<IList<Challenge>>($"{host}/wow/challenge/{realm}?locale={locale}&apikey={_apiKey}", "challenge");
+            RequestResult<IList<Challenge>> challengeList = await Get<IList<Challenge>>(region, $"{host}/wow/challenge/{realm}?locale={locale}", "challenge");
             return challengeList;
         }
 
@@ -307,7 +318,7 @@ namespace ArgentPonyWarcraftClient
         {
             string host = GetHost(region);
             string queryStringFields = fields.BuildQueryString();
-            return await Get<Character>($"{host}/wow/character/{realm}/{characterName}?&locale={locale}{queryStringFields}&apikey={_apiKey}");
+            return await Get<Character>(region, $"{host}/wow/character/{realm}/{characterName}?&locale={locale}{queryStringFields}");
         }
 
         /// <summary>
@@ -332,7 +343,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<IList<AchievementCategory>>> GetCharacterAchievementsAsync(Region region, Locale locale)
         {
             string host = GetHost(region);
-            RequestResult<IList<AchievementCategory>> achievementList = await Get<IList<AchievementCategory>>($"{host}/wow/data/character/achievements?locale={locale}&apikey={_apiKey}", "achievements");
+            RequestResult<IList<AchievementCategory>> achievementList = await Get<IList<AchievementCategory>>(region, $"{host}/wow/data/character/achievements?locale={locale}", "achievements");
             return achievementList;
         }
 
@@ -358,7 +369,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<IList<CharacterClassData>>> GetCharacterClassesAsync(Region region, Locale locale)
         {
             string host = GetHost(region);
-            RequestResult<IList<CharacterClassData>> characterClassList = await Get<IList<CharacterClassData>>($"{host}/wow/data/character/classes?locale={locale}&apikey={_apiKey}", "classes");
+            RequestResult<IList<CharacterClassData>> characterClassList = await Get<IList<CharacterClassData>>(region, $"{host}/wow/data/character/classes?locale={locale}", "classes");
             return characterClassList;
         }
 
@@ -384,7 +395,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<IList<CharacterRace>>> GetCharacterRacesAsync(Region region, Locale locale)
         {
             string host = GetHost(region);
-            RequestResult<IList<CharacterRace>> characterRaceList = await Get<IList<CharacterRace>>($"{host}/wow/data/character/races?locale={locale}&apikey={_apiKey}", "races");
+            RequestResult<IList<CharacterRace>> characterRaceList = await Get<IList<CharacterRace>>(region, $"{host}/wow/data/character/races?locale={locale}", "races");
             return characterRaceList;
         }
 
@@ -411,7 +422,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<IList<GuildCharacter>>> GetCharactersAsync(string accessToken, Region region)
         {
             string host = GetHost(region);
-            RequestResult<IList<GuildCharacter>> characters = await Get<IList<GuildCharacter>>($"{host}/wow/user/characters?access_token={accessToken}", "characters");
+            RequestResult<IList<GuildCharacter>> characters = await Get<IList<GuildCharacter>>(region, $"{host}/wow/user/characters?access_token={accessToken}", "characters");
             return characters;
         }
 
@@ -444,7 +455,7 @@ namespace ArgentPonyWarcraftClient
         {
             string host = GetHost(region);
             string queryStringFields = fields.BuildQueryString();
-            return await Get<Guild>($"{host}/wow/guild/{realm}/{Uri.EscapeUriString(guildName)}?locale={locale}{queryStringFields}&apikey={_apiKey}");
+            return await Get<Guild>(region, $"{host}/wow/guild/{realm}/{Uri.EscapeUriString(guildName)}?locale={locale}{queryStringFields}");
         }
 
         /// <summary>
@@ -469,7 +480,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<IList<AchievementCategory>>> GetGuildAchievementsAsync(Region region, Locale locale)
         {
             string host = GetHost(region);
-            RequestResult<IList<AchievementCategory>> guildAchievementsList = await Get<IList<AchievementCategory>>($"{host}/wow/data/guild/achievements?locale={locale}&apikey={_apiKey}", "achievements");
+            RequestResult<IList<AchievementCategory>> guildAchievementsList = await Get<IList<AchievementCategory>>(region, $"{host}/wow/data/guild/achievements?locale={locale}", "achievements");
             return guildAchievementsList;
         }
 
@@ -495,7 +506,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<IList<Perk>>> GetGuildPerksAsync(Region region, Locale locale)
         {
             string host = GetHost(region);
-            RequestResult<IList<Perk>> guildPerksList = await Get<IList<Perk>>($"{host}/wow/data/guild/perks?locale={locale}&apikey={_apiKey}", "perks");
+            RequestResult<IList<Perk>> guildPerksList = await Get<IList<Perk>>(region, $"{host}/wow/data/guild/perks?locale={locale}", "perks");
             return guildPerksList;
         }
 
@@ -521,7 +532,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<IList<Reward>>> GetGuildRewardsAsync(Region region, Locale locale)
         {
             string host = GetHost(region);
-            RequestResult<IList<Reward>> guildRewardsList = await Get<IList<Reward>>($"{host}/wow/data/guild/rewards?locale={locale}&apikey={_apiKey}", "rewards");
+            RequestResult<IList<Reward>> guildRewardsList = await Get<IList<Reward>>(region, $"{host}/wow/data/guild/rewards?locale={locale}", "rewards");
             return guildRewardsList;
         }
 
@@ -549,7 +560,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<Item>> GetItemAsync(int itemId, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await Get<Item>($"{host}/wow/item/{itemId}?locale={locale}&apikey={_apiKey}");
+            return await Get<Item>(region, $"{host}/wow/item/{itemId}?locale={locale}");
         }
 
         /// <summary>
@@ -574,7 +585,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<IList<ItemClass>>> GetItemClassesAsync(Region region, Locale locale)
         {
             string host = GetHost(region);
-            RequestResult<IList<ItemClass>> itemClassesList = await Get<IList<ItemClass>>($"{host}/wow/data/item/classes?locale={locale}&apikey={_apiKey}", "classes");
+            RequestResult<IList<ItemClass>> itemClassesList = await Get<IList<ItemClass>>(region, $"{host}/wow/data/item/classes?locale={locale}", "classes");
             return itemClassesList;
         }
 
@@ -602,7 +613,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<ItemSet>> GetItemSetAsync(int itemSetId, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await Get<ItemSet>($"{host}/wow/item/set/{itemSetId}?locale={locale}&apikey={_apiKey}");
+            return await Get<ItemSet>(region, $"{host}/wow/item/set/{itemSetId}?locale={locale}");
         }
 
         /// <summary>
@@ -627,7 +638,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<IList<Mount>>> GetMountsAsync(Region region, Locale locale)
         {
             string host = GetHost(region);
-            RequestResult<IList<Mount>> mountList = await Get<IList<Mount>>($"{host}/wow/mount/?locale={locale}&apikey={_apiKey}", "mounts");
+            RequestResult<IList<Mount>> mountList = await Get<IList<Mount>>(region, $"{host}/wow/mount/?locale={locale}", "mounts");
             return mountList;
         }
 
@@ -653,7 +664,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<IList<Pet>>> GetPetsAsync(Region region, Locale locale)
         {
             string host = GetHost(region);
-            RequestResult<IList<Pet>> petList = await Get<IList<Pet>>($"{host}/wow/pet/?locale={locale}&apikey={_apiKey}", "pets");
+            RequestResult<IList<Pet>> petList = await Get<IList<Pet>>(region, $"{host}/wow/pet/?locale={locale}", "pets");
             return petList;
         }
 
@@ -681,7 +692,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<PetAbility>> GetPetAbilityAsync(int abilityId, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await Get<PetAbility>($"{host}/wow/pet/ability/{abilityId}?locale={locale}&apikey={_apiKey}");
+            return await Get<PetAbility>(region, $"{host}/wow/pet/ability/{abilityId}?locale={locale}");
         }
 
         /// <summary>
@@ -708,7 +719,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<PetSpecies>> GetPetSpeciesAsync(int speciesId, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await Get<PetSpecies>($"{host}/wow/pet/species/{speciesId}?locale={locale}&apikey={_apiKey}");
+            return await Get<PetSpecies>(region, $"{host}/wow/pet/species/{speciesId}?locale={locale}");
         }
 
         /// <summary>
@@ -741,7 +752,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<PetStats>> GetPetStatsAsync(int speciesId, int level, int breedId, BattlePetQuality quality, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await Get<PetStats>($"{host}/wow/pet/stats/{speciesId}?level={level}&breedId={breedId}&qualityId={quality:D}&locale={locale}&apikey={_apiKey}");
+            return await Get<PetStats>(region, $"{host}/wow/pet/stats/{speciesId}?level={level}&breedId={breedId}&qualityId={quality:D}&locale={locale}");
         }
 
         /// <summary>
@@ -766,7 +777,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<IList<PetType>>> GetPetTypesAsync(Region region, Locale locale)
         {
             string host = GetHost(region);
-            RequestResult<IList<PetType>> petTypeList = await Get<IList<PetType>>($"{host}/wow/data/pet/types?locale={locale}&apikey={_apiKey}", "petTypes");
+            RequestResult<IList<PetType>> petTypeList = await Get<IList<PetType>>(region, $"{host}/wow/data/pet/types?locale={locale}", "petTypes");
             return petTypeList;
         }
 
@@ -794,7 +805,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<PvpLeaderboard>> GetPvpLeaderboardAsync(string bracket, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await Get<PvpLeaderboard>($"{host}/wow/leaderboard/{bracket}?locale={locale}&apikey={_apiKey}");
+            return await Get<PvpLeaderboard>(region, $"{host}/wow/leaderboard/{bracket}?locale={locale}");
         }
 
         /// <summary>
@@ -821,7 +832,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<Quest>> GetQuestAsync(int questId, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await Get<Quest>($"{host}/wow/quest/{questId}?locale={locale}&apikey={_apiKey}");
+            return await Get<Quest>(region, $"{host}/wow/quest/{questId}?locale={locale}");
         }
 
         /// <summary>
@@ -846,7 +857,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<IList<Realm>>> GetRealmStatusAsync(Region region, Locale locale)
         {
             string host = GetHost(region);
-            RequestResult<IList<Realm>> realmList = await Get<IList<Realm>>($"{host}/wow/realm/status?locale={locale}&apikey={_apiKey}", "realms");
+            RequestResult<IList<Realm>> realmList = await Get<IList<Realm>>(region, $"{host}/wow/realm/status?locale={locale}", "realms");
             return realmList;
         }
 
@@ -874,7 +885,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<Recipe>> GetRecipeAsync(int recipeId, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await Get<Recipe>($"{host}/wow/recipe/{recipeId}?locale={locale}&apikey={_apiKey}");
+            return await Get<Recipe>(region, $"{host}/wow/recipe/{recipeId}?locale={locale}");
         }
 
         /// <summary>
@@ -901,7 +912,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<Spell>> GetSpellAsync(int spellId, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await Get<Spell>($"{host}/wow/spell/{spellId}?locale={locale}&apikey={_apiKey}");
+            return await Get<Spell>(region, $"{host}/wow/spell/{spellId}?locale={locale}");
         }
 
         /// <summary>
@@ -926,7 +937,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<IDictionary<CharacterClass, TalentSet>>> GetTalentsAsync(Region region, Locale locale)
         {
             string host = GetHost(region);
-            RequestResult<IDictionary<CharacterClass, TalentSet>> talents = await Get<IDictionary<CharacterClass, TalentSet>>($"{host}/wow/data/talents?locale={locale}&apikey={_apiKey}");
+            RequestResult<IDictionary<CharacterClass, TalentSet>> talents = await Get<IDictionary<CharacterClass, TalentSet>>(region, $"{host}/wow/data/talents?locale={locale}");
             return talents;
         }
 
@@ -953,7 +964,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<UserAccount>> GetUserAsync(string accessToken, Region region)
         {
             string host = GetHost(region);
-            RequestResult<UserAccount> userAccount = await Get<UserAccount>($"{host}/account/user?access_token={accessToken}");
+            RequestResult<UserAccount> userAccount = await Get<UserAccount>(region, $"{host}/account/user?access_token={accessToken}");
             return userAccount;
         }
 
@@ -981,7 +992,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<Zone>> GetZoneAsync(int zoneId, Region region, Locale locale)
         {
             string host = GetHost(region);
-            return await Get<Zone>($"{host}/wow/zone/{zoneId}?locale={locale}&apikey={_apiKey}");
+            return await Get<Zone>(region, $"{host}/wow/zone/{zoneId}?locale={locale}");
         }
 
         /// <summary>
@@ -1006,7 +1017,7 @@ namespace ArgentPonyWarcraftClient
         public async Task<RequestResult<IList<Zone>>> GetZonesAsync(Region region, Locale locale)
         {
             string host = GetHost(region);
-            RequestResult<IList<Zone>> zoneList = await Get<IList<Zone>>($"{host}/wow/zone/?locale={locale}&apikey={_apiKey}", "zones");
+            RequestResult<IList<Zone>> zoneList = await Get<IList<Zone>>(region, $"{host}/wow/zone/?locale={locale}", "zones");
             return zoneList;
         }
 
@@ -1016,6 +1027,7 @@ namespace ArgentPonyWarcraftClient
         /// <typeparam name="T">
         ///     The return type.
         /// </typeparam>
+        /// <param name="region">The region from which to request a token.</param>
         /// <param name="requestUri">
         ///     The URI the request is sent to.
         /// </param>
@@ -1025,8 +1037,18 @@ namespace ArgentPonyWarcraftClient
         /// <returns>
         ///     The JSON response, deserialized to an object of type <typeparamref name="T"/>.
         /// </returns>
-        private async Task<RequestResult<T>> Get<T>(string requestUri, string arrayName = null)
+        private async Task<RequestResult<T>> Get<T>(Region region, string requestUri, string arrayName = null)
         {
+            // Acquire a new OAuth token if we don't have one. Get a new one if it's expired.
+            if (_token == null || DateTime.UtcNow >= _tokenExpiration)
+            {
+                _token = await GetOAuthToken(Region.US).ConfigureAwait(false);
+                _tokenExpiration = DateTime.UtcNow.AddSeconds(_token.ExpiresIn).AddSeconds(-30);
+            }
+
+            // Add an authentication header with the token.
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _token.AccessToken);
+
             // Retrieve the response.
             HttpResponseMessage response = await _client.GetAsync(requestUri).ConfigureAwait(false);
 
@@ -1046,8 +1068,7 @@ namespace ArgentPonyWarcraftClient
                 }
 
                 // If not then it is most likely a problem on our end due to an HTTP error.
-                string safeUri = requestUri.Replace(_apiKey, "{apiKey}");
-                string message = $"Response code {(int)response.StatusCode} ({response.ReasonPhrase}) does not indicate success. Request: {safeUri}";
+                string message = $"Response code {(int)response.StatusCode} ({response.ReasonPhrase}) does not indicate success. Request: {requestUri}";
 
                 throw new HttpRequestException(message);
             }
@@ -1074,6 +1095,35 @@ namespace ArgentPonyWarcraftClient
         }
 
         /// <summary>
+        ///     Get an OAuth token.
+        /// </summary>
+        /// <param name="region">The region from which to request a token.</param>
+        /// <returns>
+        ///     An OAuth token.
+        /// </returns>
+        private async Task<OAuthAccessToken> GetOAuthToken(Region region)
+        {
+            string credentials = $"{_clientId}:{_clientSecret}";
+            string host = GetOAuthHost(region);
+
+            using (var client = new HttpClient())
+            {
+                client.DefaultRequestHeaders.Accept.Clear();
+                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.UTF8.GetBytes(credentials)));
+
+                var requestBody = new FormUrlEncodedContent(new[]
+                {
+                    new KeyValuePair<string, string>("grant_type", "client_credentials")
+                });
+
+                HttpResponseMessage request = await client.PostAsync($"{host}/oauth/token", requestBody);
+                string response = await request.Content.ReadAsStringAsync();
+                return JsonConvert.DeserializeObject<OAuthAccessToken>(response);
+            }
+        }
+
+        /// <summary>
         ///     Get the host for the specified region.
         /// </summary>
         /// <param name="region">Specifies the region that the API will retrieve its data from.</param>
@@ -1095,6 +1145,31 @@ namespace ArgentPonyWarcraftClient
                 case Region.US:
                 default:
                     return "https://us.api.blizzard.com";
+            }
+        }
+
+        /// <summary>
+        ///     Get the OAuth host for the specified region.
+        /// </summary>
+        /// <param name="region">Specifies the region for which an OAuth token will be acquired.</param>
+        /// <returns>
+        ///     The OAuth host for the specified region.
+        /// </returns>
+        private static string GetOAuthHost(Region region)
+        {
+            switch (region)
+            {
+                case Region.China:
+                    return "https://cn.battle.net";
+                case Region.Europe:
+                    return "https://eu.battle.net";
+                case Region.Korea:
+                    return "https://kr.battle.net";
+                case Region.Taiwan:
+                    return "https://tw.battle.net";
+                case Region.US:
+                default:
+                    return "https://us.battle.net";
             }
         }
 

--- a/src/ArgentPonyWarcraftClient/WarcraftClient.cs
+++ b/src/ArgentPonyWarcraftClient/WarcraftClient.cs
@@ -1037,9 +1037,12 @@ namespace ArgentPonyWarcraftClient
                 if (response.Content != null)
                 {
                     string content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    RequestResult<T> requestError = JsonConvert.DeserializeObject<RequestError>(content);
 
-                    return requestError;
+                    if (!string.IsNullOrEmpty(content))
+                    {
+                        RequestResult<T> requestError = JsonConvert.DeserializeObject<RequestError>(content);
+                        return requestError;
+                    }
                 }
 
                 // If not then it is most likely a problem on our end due to an HTTP error.

--- a/src/ArgentPonyWarcraftClient/WarcraftClient.cs
+++ b/src/ArgentPonyWarcraftClient/WarcraftClient.cs
@@ -1106,21 +1106,18 @@ namespace ArgentPonyWarcraftClient
             string credentials = $"{_clientId}:{_clientSecret}";
             string host = GetOAuthHost(region);
 
-            using (var client = new HttpClient())
+            _client.DefaultRequestHeaders.Accept.Clear();
+            _client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.UTF8.GetBytes(credentials)));
+
+            var requestBody = new FormUrlEncodedContent(new[]
             {
-                client.DefaultRequestHeaders.Accept.Clear();
-                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.UTF8.GetBytes(credentials)));
+                new KeyValuePair<string, string>("grant_type", "client_credentials")
+            });
 
-                var requestBody = new FormUrlEncodedContent(new[]
-                {
-                    new KeyValuePair<string, string>("grant_type", "client_credentials")
-                });
-
-                HttpResponseMessage request = await client.PostAsync($"{host}/oauth/token", requestBody);
-                string response = await request.Content.ReadAsStringAsync();
-                return JsonConvert.DeserializeObject<OAuthAccessToken>(response);
-            }
+            HttpResponseMessage request = await _client.PostAsync($"{host}/oauth/token", requestBody);
+            string response = await request.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<OAuthAccessToken>(response);
         }
 
         /// <summary>


### PR DESCRIPTION
Migration to the library to the updated Blizzard API endpoints based on the OAuth client credentials flow based on instructions in the [Migration Guide](https://develop.battle.net/documentation/guides/migration-guide).  Updated the **README.md** file as well.  Additional work is still needed, but I think this is a good first pass.