### PR TITLE
Replaced PackageLicenseUrl with PackageLicenseExpression

### DIFF
--- a/src/ArgentPonyWarcraftClient/ArgentPonyWarcraftClient.csproj
+++ b/src/ArgentPonyWarcraftClient/ArgentPonyWarcraftClient.csproj
@@ -14,7 +14,7 @@
     <PackageProjectUrl>https://github.com/danjagnow/ArgentPonyWarcraftClient</PackageProjectUrl>
     <RepositoryUrl>https://github.com/danjagnow/ArgentPonyWarcraftClient</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageLicenseUrl>https://github.com/danjagnow/ArgentPonyWarcraftClient/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIconUrl>https://raw.githubusercontent.com/danjagnow/ArgentPonyWarcraftClient/master/ArgentPony.png</PackageIconUrl>
     <RootNamespace>ArgentPonyWarcraftClient</RootNamespace>
     <AssemblyName>ArgentPonyWarcraftClient</AssemblyName>


### PR DESCRIPTION
Replaced PackageLicenseUrl with PackageLicenseExpression based on https://github.com/NuGet/Home/issues/4628.