### PR TITLE
Updated the base URI for the China region

### DIFF
--- a/src/ArgentPonyWarcraftClient/WarcraftClient.cs
+++ b/src/ArgentPonyWarcraftClient/WarcraftClient.cs
@@ -1145,7 +1145,7 @@ namespace ArgentPonyWarcraftClient
             switch (region)
             {
                 case Region.China:
-                    return "https://cn.api.blizzard.com";
+                    return "https://gateway.battlenet.com.cn";
                 case Region.Europe:
                     return "https://eu.api.blizzard.com";
                 case Region.Korea:
@@ -1170,7 +1170,7 @@ namespace ArgentPonyWarcraftClient
             switch (region)
             {
                 case Region.China:
-                    return "https://cn.battle.net";
+                    return "https://www.battlenet.com.cn";
                 case Region.Europe:
                     return "https://eu.battle.net";
                 case Region.Korea:


### PR DESCRIPTION
Updated the base URI for the China region from https://cn.api.blizzard.com to https://gateway.battlenet.com.cn.  This matches the current documentation at https://develop.battle.net/documentation/guides/regionality-and-apis.  Also changed the base URI for OAuth for China per the documentation at https://develop.battle.net/documentation/guides/using-oauth.  Resolves #71.